### PR TITLE
[#3] User 도메인 JPA 적용

### DIFF
--- a/src/main/java/com/danahub/zipitda/user/controller/UserController.java
+++ b/src/main/java/com/danahub/zipitda/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.danahub.zipitda.user.controller;
+
+import com.danahub.zipitda.user.domain.User;
+import com.danahub.zipitda.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<User>> getAllUsers() {
+        return ResponseEntity.ok(userService.getAllUsers());
+    }
+
+    @PostMapping
+    public ResponseEntity<User> createUser(@RequestBody User user) {
+        return ResponseEntity.ok(userService.saveUser(user));
+    }
+}

--- a/src/main/java/com/danahub/zipitda/user/domain/User.java
+++ b/src/main/java/com/danahub/zipitda/user/domain/User.java
@@ -1,0 +1,40 @@
+package com.danahub.zipitda.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    private String nickname;
+    private String profileImage;
+    private Boolean isActive;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/danahub/zipitda/user/dto/UserDto.java
+++ b/src/main/java/com/danahub/zipitda/user/dto/UserDto.java
@@ -1,0 +1,5 @@
+package com.danahub.zipitda.user.dto;
+
+public class UserDto {
+
+}

--- a/src/main/java/com/danahub/zipitda/user/repository/UserRepository.java
+++ b/src/main/java/com/danahub/zipitda/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.danahub.zipitda.user.repository;
+
+import com.danahub.zipitda.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Integer> {
+}

--- a/src/main/java/com/danahub/zipitda/user/service/UserService.java
+++ b/src/main/java/com/danahub/zipitda/user/service/UserService.java
@@ -1,0 +1,25 @@
+package com.danahub.zipitda.user.service;
+
+import com.danahub.zipitda.user.domain.User;
+import com.danahub.zipitda.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+
+    public User saveUser(User user) {
+        return userRepository.save(user);
+    }
+}


### PR DESCRIPTION
- User 엔티티 추가 및 필드 정의
- @Table(name = "users")로 테이블 매핑
- UserRepository와 기본메서드 추가
- Service, Controller 기본 메서드 구현