### PR TITLE
[#5] 약관 API 개발

### DIFF
--- a/src/main/java/com/danahub/zipitda/config/SecurityConfig.java
+++ b/src/main/java/com/danahub/zipitda/config/SecurityConfig.java
@@ -13,8 +13,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/users").permitAll() // '/api/users' 경로는 인증 없이 허용
-                        .anyRequest().authenticated() // 그 외의 요청은 인증 필요
+                        .anyRequest().permitAll() // 모든 요청 인증 없이 허용 (TODO:테스트용!!이니 꼭 수정할 것)
                 );
         return http.build();
     }

--- a/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
+++ b/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
@@ -1,0 +1,31 @@
+package com.danahub.zipitda.terms.controller;
+
+import com.danahub.zipitda.terms.domain.Terms;
+import com.danahub.zipitda.terms.service.TermsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/terms")
+public class TermsController {
+
+    private final TermsService termsService;
+
+    public TermsController(TermsService termsService) {
+        this.termsService = termsService;
+    }
+
+    // 약관 목록 가져오기
+    @GetMapping
+    public ResponseEntity<List<Terms>> getAllTerms() {
+        return ResponseEntity.ok(termsService.getAllTerms());
+    }
+
+    // 특정 약관 가져오기
+    @GetMapping("/{id}")
+    public ResponseEntity<Terms> getTermsById(@PathVariable Integer id) {
+        return ResponseEntity.ok(termsService.getTermsById(id));
+    }
+}

--- a/src/main/java/com/danahub/zipitda/terms/domain/Terms.java
+++ b/src/main/java/com/danahub/zipitda/terms/domain/Terms.java
@@ -1,0 +1,40 @@
+package com.danahub.zipitda.terms.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "terms") // 약관 테이블
+@Getter
+@Setter
+public class Terms {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id; // 약관 ID
+
+    @Column(nullable = false)
+    private String title; // 약관 제목
+
+    @Column(nullable = false)
+    private String content; // 약관 내용
+
+    @Column(nullable = false)
+    private Integer version; // 약관 버전
+
+    @Column(nullable = false)
+    private Boolean isRequired; // 필수 약관 여부 (true: 필수, false: 선택)
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt; // 생성일시
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt; // 수정일시
+}

--- a/src/main/java/com/danahub/zipitda/terms/repository/TermsRepository.java
+++ b/src/main/java/com/danahub/zipitda/terms/repository/TermsRepository.java
@@ -1,0 +1,9 @@
+package com.danahub.zipitda.terms.repository;
+
+import com.danahub.zipitda.terms.domain.Terms;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TermsRepository extends JpaRepository<Terms, Integer> {
+}

--- a/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
+++ b/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
@@ -1,0 +1,27 @@
+package com.danahub.zipitda.terms.service;
+
+import com.danahub.zipitda.terms.domain.Terms;
+import com.danahub.zipitda.terms.repository.TermsRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class TermsService {
+
+    private final TermsRepository termsRepository;
+
+    public TermsService(TermsRepository termsRepository) {
+        this.termsRepository = termsRepository;
+    }
+
+    public List<Terms> getAllTerms() {
+        return termsRepository.findAll();
+    }
+
+    public Terms getTermsById(Integer id) {
+        return termsRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 약관이 존재하지 않습니다. ID: " + id));
+    }
+}


### PR DESCRIPTION
- 약관 데이터 조회 API 개발
  - 약관 목록 가져오기: /api/terms (GET)
  - 개별 약관 가져오기: /api/terms/{id} (GET)
- 약관 Entity, Service, Controller 작성
- JPA를 이용해 데이터베이스 연동
- Security 설정 변경 
  - (임시) 테스트를 위해 모든 API 인증 없이 접근 가능하도록 변경