### PR TITLE
[#7] 닉네임 중복 확인 API 개발

### DIFF
--- a/src/main/java/com/danahub/zipitda/auth/controller/AuthController.java
+++ b/src/main/java/com/danahub/zipitda/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.danahub.zipitda.auth.controller;
+
+import com.danahub.zipitda.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final UserService userService;
+
+    public AuthController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<Void> checkNickname(@RequestParam String nickname) {
+        if (userService.isNicknameAvailable(nickname)) {
+            return ResponseEntity.ok().build(); // 닉네임 사용 가능 (200 OK)
+        } else {
+            return ResponseEntity.status(409).build(); // 닉네임 중복 (409 Conflict)
+        }
+    }
+}

--- a/src/main/java/com/danahub/zipitda/user/domain/User.java
+++ b/src/main/java/com/danahub/zipitda/user/domain/User.java
@@ -1,0 +1,43 @@
+package com.danahub.zipitda.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id; // user ID
+
+    @Column(nullable = false, unique = true)
+    private String email; // 이메일 (중복 불가)
+
+    @Column(nullable = false)
+    private String password; // 패스워드
+
+    private String nickname; // 닉네임 (중복 불가)
+    private String profileImage; // 프로필 이미지
+    private Boolean isActive; // 활성 사용자 (true: 활성, false: 비활성)
+
+    @Column(nullable = false)
+    private String role; // 역할 (USER/ADMIN/SELLER/EXPERT)
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; // 생성일시
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt; // 수정일시
+}

--- a/src/main/java/com/danahub/zipitda/user/repository/UserRepository.java
+++ b/src/main/java/com/danahub/zipitda/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.danahub.zipitda.user.repository;
+
+import com.danahub.zipitda.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Integer> {
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/danahub/zipitda/user/service/UserService.java
+++ b/src/main/java/com/danahub/zipitda/user/service/UserService.java
@@ -1,0 +1,29 @@
+package com.danahub.zipitda.user.service;
+
+import com.danahub.zipitda.user.domain.User;
+import com.danahub.zipitda.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+
+    public User saveUser(User user) {
+        return userRepository.save(user);
+    }
+
+    public boolean isNicknameAvailable(String nickname) {
+        return !userRepository.existsByNickname(nickname); // 존재하지 않으면 사용 가능
+    }
+}


### PR DESCRIPTION
- 사용자 권한을 관리하기 위해 User 도메인에 role 컬럼 추가
- 닉네임 중복 확인 API 구현
  - **닉네임 중복 확인**: /api/auth/check-nickname (GET)

Closes #7
