### PR TITLE
[#5][#12] 약관 API 수정 개발 및 Logback 기본 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,20 +24,41 @@ repositories {
 }
 
 dependencies {
+	// Spring Boot Starters
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'mysql:mysql-connector-java:8.0.32' // 버전 명시
+
+	// MyBatis
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
+
+	// Database
+	implementation 'mysql:mysql-connector-java:8.0.32'  // MySQL Connector (버전 명시)
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Development Tools
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'  // 개발용
+
+	// Test Dependencies
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
-	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.mockito:mockito-core'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
+//
+//sourceSets {
+//	main {
+//		resources {
+//			// `src/main/java`에 있는 XML 파일도 리소스로 포함
+//			srcDirs = ['src/main/resources', 'src/main/java']
+//			include '**/*.xml'
+//		}
+//	}
+//}

--- a/src/main/java/com/danahub/zipitda/ZipitdaApplication.java
+++ b/src/main/java/com/danahub/zipitda/ZipitdaApplication.java
@@ -1,13 +1,14 @@
 package com.danahub.zipitda;
 
+import org.mybatis.spring.annotation.MapperScan;
+import org.mybatis.spring.boot.autoconfigure.MybatisAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = MybatisAutoConfiguration.class)
 @EnableJpaAuditing
+@MapperScan(basePackages = "com.danahub.zipitda.**.mapper")
 public class ZipitdaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/danahub/zipitda/common/domain/BaseEntity.java
+++ b/src/main/java/com/danahub/zipitda/common/domain/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.danahub.zipitda.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt; // 생성 일시
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt; // 수정 일시
+}

--- a/src/main/java/com/danahub/zipitda/config/MyBatisConfig.java
+++ b/src/main/java/com/danahub/zipitda/config/MyBatisConfig.java
@@ -1,0 +1,27 @@
+package com.danahub.zipitda.config;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class MyBatisConfig {
+
+    @Bean
+    public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
+        SqlSessionFactoryBean sessionFactory = new SqlSessionFactoryBean();
+        sessionFactory.setDataSource(dataSource);
+
+        // 매퍼 XML 파일 경로 설정
+        Resource[] mapperLocations = new PathMatchingResourcePatternResolver()
+                .getResources("classpath:mapper/*.xml");
+        sessionFactory.setMapperLocations(mapperLocations);
+
+        return sessionFactory.getObject();
+    }
+}

--- a/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
+++ b/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
@@ -1,7 +1,11 @@
 package com.danahub.zipitda.terms.controller;
 
 import com.danahub.zipitda.terms.domain.Terms;
+import com.danahub.zipitda.terms.domain.TermsId;
+import com.danahub.zipitda.terms.dto.TermsResponseDto;
 import com.danahub.zipitda.terms.service.TermsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,21 +15,39 @@ import java.util.List;
 @RequestMapping("/api/terms")
 public class TermsController {
 
+    private static final Logger logger = LoggerFactory.getLogger(TermsController.class);
+
     private final TermsService termsService;
 
     public TermsController(TermsService termsService) {
         this.termsService = termsService;
     }
 
-    // 약관 목록 가져오기
-    @GetMapping
-    public ResponseEntity<List<Terms>> getAllTerms() {
-        return ResponseEntity.ok(termsService.getAllTerms());
+    // 약관 리스트 가져오기
+    @GetMapping("/list")
+    public ResponseEntity<List<TermsResponseDto>> getTermsList() {
+        logger.info("[TermsController] /api/terms 요청 수신 - 약관 리스트 조회 시작");
+        List<TermsResponseDto> termsList = termsService.getTermsList();
+
+        if (termsList.isEmpty()) {
+            logger.warn("[TermsController] 약관 데이터가 없습니다.");
+            return ResponseEntity.noContent().build(); // 204 No Content 반환
+        }
+
+        logger.info("[TermsController] 약관 리스트 응답 성공 - 총 {}건 반환", termsList.size());
+        return ResponseEntity.ok(termsList); // 200 OK 반환
     }
 
-    // 특정 약관 가져오기
-    @GetMapping("/{id}")
-    public ResponseEntity<Terms> getTermsById(@PathVariable Integer id) {
-        return ResponseEntity.ok(termsService.getTermsById(id));
+    // 특정 약관 가져오기 (복합키)
+    @GetMapping("/{title}/{version}")
+    public ResponseEntity<Terms> getTermsByTitleAndVersion(
+            @PathVariable String title,
+            @PathVariable Integer version) {
+        logger.info("[TermsController] /api/terms/{}/{} 요청 수신 - 특정 약관 조회 시작", title, version);
+        Terms terms = termsService.getTermsByTitleAndVersion(title, version);
+
+        logger.info("[TermsController] 특정 약관 조회 성공 - title: {}, version: {}", title, version);
+        return ResponseEntity.ok(terms); // 200 OK 반환
     }
+
 }

--- a/src/main/java/com/danahub/zipitda/terms/domain/Terms.java
+++ b/src/main/java/com/danahub/zipitda/terms/domain/Terms.java
@@ -1,40 +1,26 @@
 package com.danahub.zipitda.terms.domain;
 
+import com.danahub.zipitda.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
 import java.time.LocalDateTime;
-
+// 약관 엔티티
 @Entity
 @Table(name = "terms") // 약관 테이블
 @Getter
 @Setter
-public class Terms {
+public class Terms extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id; // 약관 ID
-
-    @Column(nullable = false)
-    private String title; // 약관 제목
+    @EmbeddedId
+    private TermsId id; // 복합키 (title + version)
 
     @Column(nullable = false)
     private String content; // 약관 내용
 
     @Column(nullable = false)
-    private Integer version; // 약관 버전
-
-    @Column(nullable = false)
     private Boolean isRequired; // 필수 약관 여부 (true: 필수, false: 선택)
 
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt; // 생성일시
-
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt; // 수정일시
 }

--- a/src/main/java/com/danahub/zipitda/terms/domain/TermsId.java
+++ b/src/main/java/com/danahub/zipitda/terms/domain/TermsId.java
@@ -1,0 +1,43 @@
+package com.danahub.zipitda.terms.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import java.io.Serializable;
+import java.util.Objects;
+
+// 복합키를 정의하는 클래스
+@Getter
+@Setter
+@Embeddable
+public class TermsId implements Serializable {
+
+    @Column(nullable = false)
+    private String title; // 약관 제목
+
+    @Column(nullable = false)
+    private Integer version; // 약관 버전
+
+    public TermsId(String title, Integer version) {
+        this.title = title;
+        this.version = version;
+    }
+
+    public TermsId() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TermsId termsId = (TermsId) o;
+        return Objects.equals(title, termsId.title) && Objects.equals(version, termsId.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(title, version);
+    }
+}

--- a/src/main/java/com/danahub/zipitda/terms/dto/TermsResponseDto.java
+++ b/src/main/java/com/danahub/zipitda/terms/dto/TermsResponseDto.java
@@ -1,0 +1,14 @@
+package com.danahub.zipitda.terms.dto;
+
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+public class TermsResponseDto {
+    private String title;
+    private int version;
+    private String content;
+    private boolean isRequired;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/danahub/zipitda/terms/mapper/TermsMapper.java
+++ b/src/main/java/com/danahub/zipitda/terms/mapper/TermsMapper.java
@@ -1,0 +1,12 @@
+package com.danahub.zipitda.terms.mapper;
+import com.danahub.zipitda.terms.dto.TermsResponseDto;
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Mapper
+//@Repository("termsMapperBean")
+public interface TermsMapper {
+    List<TermsResponseDto> getTermsList();
+}

--- a/src/main/java/com/danahub/zipitda/terms/repository/TermsRepository.java
+++ b/src/main/java/com/danahub/zipitda/terms/repository/TermsRepository.java
@@ -1,9 +1,10 @@
 package com.danahub.zipitda.terms.repository;
 
 import com.danahub.zipitda.terms.domain.Terms;
+import com.danahub.zipitda.terms.domain.TermsId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TermsRepository extends JpaRepository<Terms, Integer> {
+public interface TermsRepository extends JpaRepository<Terms, TermsId> {
 }

--- a/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
+++ b/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
@@ -1,27 +1,43 @@
 package com.danahub.zipitda.terms.service;
 
+import com.danahub.zipitda.terms.controller.TermsController;
 import com.danahub.zipitda.terms.domain.Terms;
+import com.danahub.zipitda.terms.domain.TermsId;
+import com.danahub.zipitda.terms.dto.TermsResponseDto;
+import com.danahub.zipitda.terms.mapper.TermsMapper;
 import com.danahub.zipitda.terms.repository.TermsRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class TermsService {
 
+    private static final Logger logger = LoggerFactory.getLogger(TermsController.class);
+
+    private final TermsMapper termsMapper;
     private final TermsRepository termsRepository;
 
-    public TermsService(TermsRepository termsRepository) {
-        this.termsRepository = termsRepository;
+
+    // 약관 리스트 가져오기
+    public List<TermsResponseDto> getTermsList() {
+        logger.info("[TermsService] getTermsList - 약관 리스트 조회 시작");
+        List<TermsResponseDto> termsList = termsMapper.getTermsList();
+        logger.info("[TermsService] 약관 {}건 조회 성공", termsList.size());
+        return termsList;
     }
 
-    public List<Terms> getAllTerms() {
-        return termsRepository.findAll();
+    // 특정 약관 가져오기 (복합키)
+    public Terms getTermsByTitleAndVersion(String title, Integer version) {
+        TermsId termsId = new TermsId(title, version);
+        return termsRepository.findById(termsId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 약관을 찾을 수 없습니다."));
     }
 
-    public Terms getTermsById(Integer id) {
-        return termsRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 약관이 존재하지 않습니다. ID: " + id));
-    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,12 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+
+# MyBatis Mapper ??
+mybatis.mapper-locations=classpath:mapper/*.xml
+mybatis.configuration.map-underscore-to-camel-case=true
+mybatis.configuration.default-fetch-size=100
+mybatis.configuration.default-statement-timeout=30
+
+logging.level.org.mybatis=DEBUG
+logging.level.org.springframework=DEBUG

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- 콘솔 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss} %-5level [%logger{20}] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일 (일별 분리) -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/application.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/application-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory> <!-- 최근 7일 유지 -->
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level [%logger{20}] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 루트 로거 (기본 로그 레벨: info) -->
+    <root level="info">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="FILE" />
+    </root>
+
+    <!-- 패키지별 로그 레벨 설정 -->
+    <logger name="com.danahub" level="debug" /> <!-- 내 코드 디버그용 -->
+    <logger name="org.springframework" level="warn" /> <!-- 스프링 경고만 출력 -->
+</configuration>

--- a/src/main/resources/mapper/TermsMapper.xml
+++ b/src/main/resources/mapper/TermsMapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.danahub.zipitda.terms.mapper.TermsMapper">
+
+    <select id="getTermsList" resultType="com.danahub.zipitda.terms.dto.TermsResponseDto">
+        SELECT
+            t1.title,
+            t1.version,
+            t1.content,
+            t1.is_required,
+            t1.created_at,
+            t1.updated_at
+        FROM TERMS t1
+        WHERE t1.version = (SELECT MAX(t2.version)
+                            FROM TERMS t2
+                            WHERE t1.title = t2.title)
+    </select>
+
+</mapper>

--- a/src/test/java/com/danahub/zipitda/terms/mapper/TermsMapperTest.java
+++ b/src/test/java/com/danahub/zipitda/terms/mapper/TermsMapperTest.java
@@ -1,0 +1,29 @@
+package com.danahub.zipitda.terms.mapper;
+
+import com.danahub.zipitda.terms.dto.TermsResponseDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+public class TermsMapperTest {
+
+    @Autowired
+    private TermsMapper termsMapper;
+
+    @Test
+    public void testGetTermsList() {
+        // when
+        List<TermsResponseDto> termsList = termsMapper.getTermsList();
+
+        // then
+        Assertions.assertNotNull(termsList, "The result should not be null");
+        Assertions.assertFalse(termsList.isEmpty(), "The terms list should not be empty");
+
+        // Optional: 출력 결과 확인
+        termsList.forEach(terms -> System.out.println(terms));
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,9 @@
+## Test DB
+spring.datasource.url=jdbc:mysql://localhost:3306/zipitda_test
+spring.datasource.username=zipitda_test_user
+spring.datasource.password=test_password123
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
- 약관 데이터 조회 API 개발
  - 약관 목록 가져오기: /api/terms (GET) mybatis
  - 개별 약관 가져오기: /api/terms/{title}/{version} (GET) JPA
- terms Entity 수정
  - id 삭제 후 title, version으로 복합키 생성

- logback 초기 설정

Closes #5
Closes #12