### PR TITLE
[#34] 카드 게시글 CRUD 기능 추가

### DIFF
--- a/src/main/java/com/danahub/zipitda/auth/service/provider/NaverAuthProvider.java
+++ b/src/main/java/com/danahub/zipitda/auth/service/provider/NaverAuthProvider.java
@@ -1,0 +1,4 @@
+package com.danahub.zipitda.auth.service.provider;
+
+public class NaverAuthProvider {
+}

--- a/src/main/java/com/danahub/zipitda/common/aop/PostAuthorizationAspect.java
+++ b/src/main/java/com/danahub/zipitda/common/aop/PostAuthorizationAspect.java
@@ -1,0 +1,57 @@
+package com.danahub.zipitda.common.aop;
+
+import com.danahub.zipitda.common.exception.ErrorType;
+import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.danahub.zipitda.community.domain.Post;
+import com.danahub.zipitda.community.dto.PostRequestDto;
+import com.danahub.zipitda.community.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+/**
+ * 게시글 권한 체크 AOP (DTO 활용)
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PostAuthorizationAspect {
+
+    private final PostRepository postRepository;
+
+    // 게시글 수정/삭제 요청 전에 권한을 체크하는 AOP
+    @Before("@annotation(com.danahub.zipitda.common.aop.PostAuthorizationCheck)")
+    public void checkPostAuthorization(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+
+        PostRequestDto requestDto = null;
+        for (Object arg : args) {
+            if (arg instanceof PostRequestDto dto) {
+                requestDto = dto;
+                break;
+            }
+        }
+
+        if (requestDto == null) {
+            throw new ZipitdaException(ErrorType.MISSING_REQUIRED_VALUE);
+        }
+
+        Long postId = requestDto.postId(); // 게시글 ID
+        Long userId = requestDto.userId(); // 요청한 사용자 ID
+
+        // 게시글 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
+
+        // 권한 체크 - 요청한 userId와 게시글 작성자의 userId 비교
+        if (!post.getUserId().equals(userId)) {
+            throw new ZipitdaException(ErrorType.ACCESS_DENIED);
+        }
+
+        log.info("게시글 권한 체크 완료 - postId: {}, userId: {}", postId, userId);
+    }
+}

--- a/src/main/java/com/danahub/zipitda/common/aop/PostAuthorizationCheck.java
+++ b/src/main/java/com/danahub/zipitda/common/aop/PostAuthorizationCheck.java
@@ -1,0 +1,11 @@
+package com.danahub.zipitda.common.aop;
+
+import java.lang.annotation.*;
+
+
+// 게시글 수정/삭제 시 권한 체크를 수행하는 어노테이션
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface PostAuthorizationCheck {
+}

--- a/src/main/java/com/danahub/zipitda/common/dto/CommonResponse.java
+++ b/src/main/java/com/danahub/zipitda/common/dto/CommonResponse.java
@@ -6,6 +6,10 @@ public record CommonResponse<T>(int code, String message, T data) {
         return new CommonResponse<>(0, "Success", data);
     }
 
+    public static <T> CommonResponse<T> success() {
+        return new CommonResponse<>(0, "Success", null);
+    }
+
     public static <T> CommonResponse<T> error(int code, String message) {
         return new CommonResponse<>(code, message, null);
     }

--- a/src/main/java/com/danahub/zipitda/community/controller/PostController.java
+++ b/src/main/java/com/danahub/zipitda/community/controller/PostController.java
@@ -1,12 +1,20 @@
 package com.danahub.zipitda.community.controller;
 
 import com.danahub.zipitda.common.dto.CommonResponse;
+import com.danahub.zipitda.common.exception.ErrorType;
+import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.danahub.zipitda.community.domain.Post;
+import com.danahub.zipitda.community.dto.PostDetailResponseDto;
 import com.danahub.zipitda.community.dto.PostRequestDto;
 import com.danahub.zipitda.community.dto.PostResponseDto;
 import com.danahub.zipitda.community.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,16 +33,18 @@ public class PostController {
         return CommonResponse.success(postService.createPost(requestDto));
     }
 
-    @GetMapping("/{id}")
-    @Operation(summary = "게시글 조회 API", description = "게시글 ID로 게시글을 조회합니다.")
-    public CommonResponse<PostResponseDto> getPost(@PathVariable Long id) {
-        return CommonResponse.success(postService.getPost(id));
+    @GetMapping("/{postId}")
+    @Operation(summary = "게시글 상세 조회 API", description = "게시글의 상세 정보를 조회합니다. (제목, 내용, 이미지, 작성자, 댓글 수, 좋아요 수, 북마크 수 포함)")
+    public CommonResponse<PostDetailResponseDto> getPostDetail(@PathVariable Long postId) {
+        return CommonResponse.success(postService.getPostDetail(postId));
     }
 
     @GetMapping
-    @Operation(summary = "전체 게시글 조회 API", description = "모든 게시글을 조회합니다.")
-    public CommonResponse<List<PostResponseDto>> getAllPosts() {
-        return CommonResponse.success(postService.getAllPosts());
+    @Operation(summary = "전체 게시글 조회 API", description = "페이지네이션을 적용하여 최신순으로 정렬된 게시글을 조회합니다. 좋아요순으로 정렬 가능.")
+    public CommonResponse<Page<PostResponseDto>> getAllPosts(
+            Pageable pageable,
+            @RequestParam(required = false, defaultValue = "latest") String sortBy) {
+        return CommonResponse.success(postService.getAllPosts(pageable, sortBy));
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/danahub/zipitda/community/controller/PostController.java
+++ b/src/main/java/com/danahub/zipitda/community/controller/PostController.java
@@ -1,0 +1,53 @@
+package com.danahub.zipitda.community.controller;
+
+import com.danahub.zipitda.common.dto.CommonResponse;
+import com.danahub.zipitda.community.dto.PostRequestDto;
+import com.danahub.zipitda.community.dto.PostResponseDto;
+import com.danahub.zipitda.community.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/community/posts")
+@RequiredArgsConstructor
+@Tag(name = "Post", description = "게시글 API")
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping
+    @Operation(summary = "게시글 등록 API", description = "새로운 게시글을 등록합니다.")
+    public CommonResponse<Long> createPost(@RequestBody PostRequestDto requestDto) {
+        return CommonResponse.success(postService.createPost(requestDto));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "게시글 조회 API", description = "게시글 ID로 게시글을 조회합니다.")
+    public CommonResponse<PostResponseDto> getPost(@PathVariable Long id) {
+        return CommonResponse.success(postService.getPost(id));
+    }
+
+    @GetMapping
+    @Operation(summary = "전체 게시글 조회 API", description = "모든 게시글을 조회합니다.")
+    public CommonResponse<List<PostResponseDto>> getAllPosts() {
+        return CommonResponse.success(postService.getAllPosts());
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "게시글 수정 API", description = "게시글을 수정합니다.")
+    public CommonResponse<Void> updatePost(@PathVariable Long id, @RequestBody PostRequestDto requestDto) {
+        postService.updatePost(id, requestDto);
+        return CommonResponse.success();
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "게시글 삭제 API", description = "게시글을 삭제합니다.")
+    public CommonResponse<Void> deletePost(@PathVariable Long id) {
+        postService.deletePost(id);
+        return CommonResponse.success();
+    }
+}

--- a/src/main/java/com/danahub/zipitda/community/controller/PostController.java
+++ b/src/main/java/com/danahub/zipitda/community/controller/PostController.java
@@ -47,17 +47,17 @@ public class PostController {
         return CommonResponse.success(postService.getAllPosts(pageable, sortBy));
     }
 
-    @PutMapping("/{id}")
+    @PutMapping
     @Operation(summary = "게시글 수정 API", description = "게시글을 수정합니다.")
-    public CommonResponse<Void> updatePost(@PathVariable Long id, @RequestBody PostRequestDto requestDto) {
-        postService.updatePost(id, requestDto);
+    public CommonResponse<Void> updatePost(@RequestBody PostRequestDto requestDto) {
+        postService.updatePost(requestDto);
         return CommonResponse.success();
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping
     @Operation(summary = "게시글 삭제 API", description = "게시글을 삭제합니다.")
-    public CommonResponse<Void> deletePost(@PathVariable Long id) {
-        postService.deletePost(id);
+    public CommonResponse<Void> deletePost(@RequestBody PostRequestDto requestDto) {
+        postService.deletePost(requestDto);
         return CommonResponse.success();
     }
 }

--- a/src/main/java/com/danahub/zipitda/community/controller/PostController.java
+++ b/src/main/java/com/danahub/zipitda/community/controller/PostController.java
@@ -1,9 +1,6 @@
 package com.danahub.zipitda.community.controller;
 
 import com.danahub.zipitda.common.dto.CommonResponse;
-import com.danahub.zipitda.common.exception.ErrorType;
-import com.danahub.zipitda.common.exception.ZipitdaException;
-import com.danahub.zipitda.community.domain.Post;
 import com.danahub.zipitda.community.dto.PostDetailResponseDto;
 import com.danahub.zipitda.community.dto.PostRequestDto;
 import com.danahub.zipitda.community.dto.PostResponseDto;
@@ -12,12 +9,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/community/posts")

--- a/src/main/java/com/danahub/zipitda/community/domain/Bookmark.java
+++ b/src/main/java/com/danahub/zipitda/community/domain/Bookmark.java
@@ -1,0 +1,37 @@
+package com.danahub.zipitda.community.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "bookmarks")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Bookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 북마크 ID
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private TargetType targetType; // 대상 유형 ("POST", "PRODUCT", "REVIEW")
+
+    @Column(nullable = false)
+    private Long targetId; // 대상 ID
+
+    @Column(nullable = false)
+    private Long userId; // 북마크한 사용자 ID
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; // 생성일시
+}

--- a/src/main/java/com/danahub/zipitda/community/domain/Image.java
+++ b/src/main/java/com/danahub/zipitda/community/domain/Image.java
@@ -1,0 +1,37 @@
+package com.danahub.zipitda.community.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "images")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 이미지 ID
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TargetType targetType; // POST / PRODUCT / REVIEW 등
+
+    @Column(nullable = false)
+    private Long targetId; // 대상 ID
+
+    @Column(nullable = false)
+    private String imageUrl; // 이미지 URL
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; // 생성일시
+}

--- a/src/main/java/com/danahub/zipitda/community/domain/Like.java
+++ b/src/main/java/com/danahub/zipitda/community/domain/Like.java
@@ -1,0 +1,32 @@
+package com.danahub.zipitda.community.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "likes")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 좋아요 ID
+
+    @Column(nullable = false)
+    private Long userId; // 좋아요 누른 사용자 ID
+
+    @Column(nullable = false)
+    private String targetType; // 좋아요 대상 타입 ("POST", "PRODUCT", "REVIEW")
+
+    @Column(nullable = false)
+    private Long targetId; // 좋아요가 속한 대상 ID
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now(); // 좋아요 누른 시간
+}

--- a/src/main/java/com/danahub/zipitda/community/domain/Post.java
+++ b/src/main/java/com/danahub/zipitda/community/domain/Post.java
@@ -1,0 +1,35 @@
+package com.danahub.zipitda.community.domain;
+
+import com.danahub.zipitda.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "posts")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 게시글 ID
+
+    @Column(nullable = false)
+    private Long userId; // 작성자 ID
+
+    @Column(nullable = false)
+    private String title; // 제목
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content; // 내용
+
+}

--- a/src/main/java/com/danahub/zipitda/community/domain/TargetType.java
+++ b/src/main/java/com/danahub/zipitda/community/domain/TargetType.java
@@ -1,0 +1,5 @@
+package com.danahub.zipitda.community.domain;
+
+public enum TargetType {
+    POST, PRODUCT, REVIEW
+}

--- a/src/main/java/com/danahub/zipitda/community/dto/PostDetailResponseDto.java
+++ b/src/main/java/com/danahub/zipitda/community/dto/PostDetailResponseDto.java
@@ -1,0 +1,14 @@
+package com.danahub.zipitda.community.dto;
+
+import java.time.LocalDateTime;
+
+public record PostDetailResponseDto(
+        Long id,
+        Long userId,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        int likeCount,
+        int bookmarkCount
+) {}

--- a/src/main/java/com/danahub/zipitda/community/dto/PostRequestDto.java
+++ b/src/main/java/com/danahub/zipitda/community/dto/PostRequestDto.java
@@ -1,6 +1,7 @@
 package com.danahub.zipitda.community.dto;
 
 public record PostRequestDto (
+        Long postId,
         Long userId,
         String title,
         String content

--- a/src/main/java/com/danahub/zipitda/community/dto/PostRequestDto.java
+++ b/src/main/java/com/danahub/zipitda/community/dto/PostRequestDto.java
@@ -1,8 +1,19 @@
 package com.danahub.zipitda.community.dto;
 
-public record PostRequestDto (
+import jakarta.validation.constraints.*;
+
+public record PostRequestDto(
+
         Long postId,
+
+        @NotNull(message = "사용자 ID는 필수입니다.")
         Long userId,
+
+        @NotBlank(message = "제목을 입력해야 합니다.")
+        @Size(max = 100, message = "제목은 최대 100자까지 입력 가능합니다.")
         String title,
+
+        @NotBlank(message = "내용을 입력해야 합니다.")
+        @Size(max = 2000, message = "내용은 최대 2000자까지 입력 가능합니다.")
         String content
-){ }
+) { }

--- a/src/main/java/com/danahub/zipitda/community/dto/PostRequestDto.java
+++ b/src/main/java/com/danahub/zipitda/community/dto/PostRequestDto.java
@@ -1,0 +1,7 @@
+package com.danahub.zipitda.community.dto;
+
+public record PostRequestDto (
+        Long userId,
+        String title,
+        String content
+){ }

--- a/src/main/java/com/danahub/zipitda/community/dto/PostResponseDto.java
+++ b/src/main/java/com/danahub/zipitda/community/dto/PostResponseDto.java
@@ -1,0 +1,12 @@
+package com.danahub.zipitda.community.dto;
+
+import java.time.LocalDateTime;
+
+public record PostResponseDto(
+        Long id,
+        Long userId,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/danahub/zipitda/community/repository/PostRepository.java
+++ b/src/main/java/com/danahub/zipitda/community/repository/PostRepository.java
@@ -9,11 +9,11 @@ import org.springframework.data.jpa.repository.Query;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 좋아요 개수 조회
-    @Query("SELECT COUNT(l) FROM Likes l WHERE l.targetId = :postId AND l.targetType = 'POST'")
+    @Query("SELECT COUNT(l) FROM Like l WHERE l.targetId = :postId AND l.targetType = 'POST'")
     int countLikesByPostId(Long postId);
 
     // 북마크 개수 조회
-    @Query("SELECT COUNT(b) FROM Bookmarks b WHERE b.targetId = :postId AND b.targetType = 'POST'")
+    @Query("SELECT COUNT(b) FROM Bookmark b WHERE b.targetId = :postId AND b.targetType = 'POST'")
     int countBookmarksByPostId(Long postId);
 
     // 페이징 및 정렬 적용된 게시글 목록 조회

--- a/src/main/java/com/danahub/zipitda/community/repository/PostRepository.java
+++ b/src/main/java/com/danahub/zipitda/community/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.danahub.zipitda.community.repository;
+
+import com.danahub.zipitda.community.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/danahub/zipitda/community/repository/PostRepository.java
+++ b/src/main/java/com/danahub/zipitda/community/repository/PostRepository.java
@@ -1,7 +1,21 @@
 package com.danahub.zipitda.community.repository;
 
 import com.danahub.zipitda.community.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    // 좋아요 개수 조회
+    @Query("SELECT COUNT(l) FROM Likes l WHERE l.targetId = :postId AND l.targetType = 'POST'")
+    int countLikesByPostId(Long postId);
+
+    // 북마크 개수 조회
+    @Query("SELECT COUNT(b) FROM Bookmarks b WHERE b.targetId = :postId AND b.targetType = 'POST'")
+    int countBookmarksByPostId(Long postId);
+
+    // 페이징 및 정렬 적용된 게시글 목록 조회
+    Page<Post> findAll(Pageable pageable);
 }

--- a/src/main/java/com/danahub/zipitda/community/service/PostService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/PostService.java
@@ -3,10 +3,15 @@ package com.danahub.zipitda.community.service;
 import com.danahub.zipitda.common.exception.ErrorType;
 import com.danahub.zipitda.common.exception.ZipitdaException;
 import com.danahub.zipitda.community.domain.Post;
+import com.danahub.zipitda.community.dto.PostDetailResponseDto;
 import com.danahub.zipitda.community.dto.PostRequestDto;
 import com.danahub.zipitda.community.dto.PostResponseDto;
 import com.danahub.zipitda.community.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,29 +34,46 @@ public class PostService {
         return postRepository.save(post).getId();
     }
 
-    // 게시글 단건 조회
+    // 게시글 상세 조회
     @Transactional(readOnly = true)
-    public PostResponseDto getPost(Long id) {
-        Post post = postRepository.findById(id)
+    public PostDetailResponseDto getPostDetail(Long postId) {
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
-        return new PostResponseDto(
-                post.getId(), post.getUserId(), post.getTitle(),
-                post.getContent(), post.getCreatedAt(), post.getUpdatedAt()
+
+        int likeCount = postRepository.countLikesByPostId(postId);
+        int bookmarkCount = postRepository.countBookmarksByPostId(postId);
+
+        return new PostDetailResponseDto(
+                post.getId(),
+                post.getUserId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getCreatedAt(),
+                post.getUpdatedAt(),
+                likeCount,
+                bookmarkCount
         );
     }
 
-    // 전체 게시글 조회
+    // 전체 게시글 조회 (페이징 + 정렬)
     @Transactional(readOnly = true)
-    public List<PostResponseDto> getAllPosts() {
-        return postRepository.findAll().stream()
-                .map(post -> new PostResponseDto(
-                                post.getId(),
-                                post.getUserId(),
-                                post.getTitle(),
-                                post.getContent(),
-                                post.getCreatedAt(),
-                                post.getUpdatedAt()
-                            )).toList();
+    public Page<PostResponseDto> getAllPosts(Pageable pageable, String sortBy) {
+        Sort sort = switch (sortBy) {
+            case "likes" -> Sort.by(Sort.Order.desc("likeCount"));
+            case "comments" -> Sort.by(Sort.Order.desc("commentCount"));
+            default -> Sort.by(Sort.Order.desc("createdAt")); // 최신순 (기본값)
+        };
+
+        Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+        return postRepository.findAll(sortedPageable).map(
+                post -> new PostResponseDto(
+                        post.getId(),
+                        post.getUserId(),
+                        post.getTitle(),
+                        post.getContent(),
+                        post.getCreatedAt(),
+                        post.getUpdatedAt()
+                ));
     }
 
     // 게시글 수정

--- a/src/main/java/com/danahub/zipitda/community/service/PostService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/PostService.java
@@ -1,0 +1,74 @@
+package com.danahub.zipitda.community.service;
+
+import com.danahub.zipitda.common.exception.ErrorType;
+import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.danahub.zipitda.community.domain.Post;
+import com.danahub.zipitda.community.dto.PostRequestDto;
+import com.danahub.zipitda.community.dto.PostResponseDto;
+import com.danahub.zipitda.community.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    // 게시글 생성
+    @Transactional
+    public Long createPost(PostRequestDto requestDto) {
+        Post post = Post.builder()
+                .userId(requestDto.userId())
+                .title(requestDto.title())
+                .content(requestDto.content())
+                .build();
+        return postRepository.save(post).getId();
+    }
+
+    // 게시글 단건 조회
+    @Transactional(readOnly = true)
+    public PostResponseDto getPost(Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
+        return new PostResponseDto(
+                post.getId(), post.getUserId(), post.getTitle(),
+                post.getContent(), post.getCreatedAt(), post.getUpdatedAt()
+        );
+    }
+
+    // 전체 게시글 조회
+    @Transactional(readOnly = true)
+    public List<PostResponseDto> getAllPosts() {
+        return postRepository.findAll().stream()
+                .map(post -> new PostResponseDto(
+                                post.getId(),
+                                post.getUserId(),
+                                post.getTitle(),
+                                post.getContent(),
+                                post.getCreatedAt(),
+                                post.getUpdatedAt()
+                            )).toList();
+    }
+
+    // 게시글 수정
+    @Transactional
+    public void updatePost(Long id, PostRequestDto requestDto) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
+        post.setTitle(requestDto.title());
+        post.setContent(requestDto.content());
+    }
+
+    // 게시글 삭제
+    @Transactional
+    public void deletePost(Long id) {
+        if (!postRepository.existsById(id)) {
+            throw new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND);
+        }
+        postRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/danahub/zipitda/community/service/PostService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/PostService.java
@@ -8,6 +8,7 @@ import com.danahub.zipitda.community.dto.PostDetailResponseDto;
 import com.danahub.zipitda.community.dto.PostRequestDto;
 import com.danahub.zipitda.community.dto.PostResponseDto;
 import com.danahub.zipitda.community.repository.PostRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -24,8 +25,7 @@ public class PostService {
 
     // 게시글 생성
     @Transactional
-    public Long createPost(PostRequestDto requestDto) {
-        validatePostRequest(requestDto);
+    public Long createPost(@Valid PostRequestDto requestDto) {
 
         Post post = Post.builder()
                 .userId(requestDto.userId())
@@ -94,7 +94,7 @@ public class PostService {
     public void deletePost(PostRequestDto requestDto) {
         postRepository.deleteById(requestDto.postId());
     }
-
+/*
     // 게시글 검증
     private void validatePostRequest(PostRequestDto requestDto) {
         if (requestDto.title() == null || requestDto.title().isBlank()) {
@@ -103,5 +103,5 @@ public class PostService {
         if (requestDto.content() == null || requestDto.content().isBlank()) {
             throw new ZipitdaException(ErrorType.MISSING_REQUIRED_VALUE);
         }
-    }
+    }*/
 }


### PR DESCRIPTION
- 게시글 등록 API 추가 (POST /api/community/posts)
- 게시글 수정 API 추가 (PUT /api/community/posts/{postId})
- 게시글 삭제 API 추가 (DELETE /api/community/posts/{postId})
- 특정 게시글 상세 조회 API 추가 (GET /api/community/posts/{postId})
  - 게시글의 상세 정보(제목, 내용, 작성자, 작성일) 제공
  - 댓글 수, 좋아요 수, 북마크 수 포함하여 반환
- 전체 게시글 페이징 조회 API 추가 (GET /api/community/posts)
  - 최신순(기본값), 좋아요순, 댓글순 정렬 가능 (sortBy 파라미터 추가)
  - Page<PostResponseDto> 형태로 반환
- PostService, PostRepository 수정
  - PostRepository에서 댓글 수, 좋아요 수, 북마크 수를 조회하는 메서드 추가
  - PostService에서 정렬 조건 적용하여 게시글 목록 조회
- Swagger 적용
  - API 문서 자동화 적용 (@Operation 활용)
Closes #34 