### PR TITLE
[#43][#44] SpringSecurity를 이용한 로그인처리

### DIFF
--- a/src/main/java/com/danahub/zipitda/auth/controller/AuthController.java
+++ b/src/main/java/com/danahub/zipitda/auth/controller/AuthController.java
@@ -2,14 +2,14 @@ package com.danahub.zipitda.auth.controller;
 
 import com.danahub.zipitda.auth.dto.LoginRequestDto;
 import com.danahub.zipitda.auth.dto.LoginResponseDto;
-import com.danahub.zipitda.auth.dto.LogoutRequestDto;
-import com.danahub.zipitda.auth.dto.PasswordChangeRequestDto;
 import com.danahub.zipitda.auth.service.AuthService;
 import com.danahub.zipitda.common.dto.CommonResponse;
 import com.danahub.zipitda.user.dto.UserResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,30 +21,31 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    @Operation(summary = "일반 로그인 API", description = "사용자가 이메일, 비밀번호를 입력하면\n" +
-            "JWT 액세스 토큰/리프레시 토큰을 발급하여 로그인합니다.")
+    @Operation(summary = "일반 로그인 API", description = "사용자가 이메일, 비밀번호를 입력하면 JWT 액세스 토큰/리프레시 토큰을 발급하여 로그인합니다.")
     public CommonResponse<LoginResponseDto> login(@RequestBody LoginRequestDto request) {
         return CommonResponse.success(authService.login(request));
     }
-
     @GetMapping("/user-info")
     @Operation(summary = "사용자 정보 조회", description = "현재 로그인한 사용자의 정보를 반환합니다.")
-    public CommonResponse<UserResponseDto> getUserInfo(@RequestHeader("Authorization") String token) {
-        String jwtToken = token.replace("Bearer ", ""); // "Bearer " 제거
-        return CommonResponse.success(authService.getUserInfo(jwtToken));
+    public CommonResponse<UserResponseDto> getUserInfo(Authentication authentication) {
+        String email = authentication.getName();
+        return CommonResponse.success(authService.getUserInfo(email));
     }
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃 API", description = "사용자의 인증 세션을 종료하고, 서버에서 리프레시 토큰을 무효화합니다.")
-    public CommonResponse<String> logout(@RequestBody LogoutRequestDto request) {
-        authService.logout(request.email());
-        return CommonResponse.success(request.email()+"님이 로그아웃 했습니다.");
+    public CommonResponse<String> logout(@RequestHeader("Authorization") String token) {
+        String jwtToken = token.replace("Bearer ", "");
+        authService.logout(jwtToken); // 이제 email 대신 JWT Token을 이용해서 로그아웃 처리
+        return CommonResponse.success("로그아웃 되었습니다.");
     }
 
     @PutMapping("/changePassword")
     @Operation(summary = "비밀번호 변경 API", description = "기존 비밀번호를 삭제하고 새 비밀번호를 설정합니다.")
-    public CommonResponse<String> changePassword(@RequestBody PasswordChangeRequestDto request) {
-        authService.changePassword(request.email(), request.newPassword());
+    public CommonResponse<String> changePassword(@RequestBody String newPassword) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName(); // 현재 로그인한 사용자 이메일 가져오기
+        authService.changePassword(email, newPassword);
         return CommonResponse.success("비밀번호가 성공적으로 변경되었습니다.");
     }
 }

--- a/src/main/java/com/danahub/zipitda/auth/controller/SocialLoginController.java
+++ b/src/main/java/com/danahub/zipitda/auth/controller/SocialLoginController.java
@@ -1,12 +1,8 @@
 package com.danahub.zipitda.auth.controller;
 
-import com.danahub.zipitda.auth.dto.LoginResponseDto;
 import com.danahub.zipitda.auth.dto.SocialLoginResponseDto;
 import com.danahub.zipitda.auth.service.SocialLoginService;
 import com.danahub.zipitda.common.dto.CommonResponse;
-import com.danahub.zipitda.user.dto.UserResponseDto;
-import io.swagger.v3.oas.annotations.Hidden;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +12,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-
-import java.util.Map;
 
 @Controller
 @RequestMapping("/social-login")

--- a/src/main/java/com/danahub/zipitda/auth/service/AuthService.java
+++ b/src/main/java/com/danahub/zipitda/auth/service/AuthService.java
@@ -29,7 +29,6 @@ public class AuthService {
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
 
-    @Transactional
     public LoginResponseDto login(LoginRequestDto request) {
         // 이메일로 사용자 찾기
         User user = userRepository.findByEmail(request.email())
@@ -55,15 +54,10 @@ public class AuthService {
         return new LoginResponseDto(accessToken, refreshToken);
     }
 
-    public UserResponseDto getUserInfo(String jwtToken) {
-        // JWT 토큰에서 이메일 추출
-        String email = jwtProvider.getEmailFromToken(jwtToken);
-
-        // 사용자 조회
+    public UserResponseDto getUserInfo(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new ZipitdaException(ErrorType.USER_NOT_FOUND));
 
-        // UserResponseDto 반환
         return new UserResponseDto(
                 user.getEmail(),
                 user.getNickname(),
@@ -72,7 +66,6 @@ public class AuthService {
         );
     }
 
-    @Transactional
     public void logout(String email) {
         // Redis에서 Access Token과 Refresh Token 삭제
         redisTemplate.delete(ACCESS_TOKEN_PREFIX + email);
@@ -86,8 +79,6 @@ public class AuthService {
         return storedAccessToken != null && storedAccessToken.equals(token);
     }
 
-
-    @Transactional
     public void changePassword(String email, String newPassword) {
 
         // 사용자 조회

--- a/src/main/java/com/danahub/zipitda/common/exception/ZipitdaException.java
+++ b/src/main/java/com/danahub/zipitda/common/exception/ZipitdaException.java
@@ -1,10 +1,12 @@
 package com.danahub.zipitda.common.exception;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.Map;
 import java.util.function.Consumer;
 @Getter
+@AllArgsConstructor
 public class ZipitdaException extends RuntimeException {
     private final ErrorType errorType;
     private final Map<String, Object> parameters;
@@ -27,11 +29,11 @@ public class ZipitdaException extends RuntimeException {
         this.exception = null;
     }
 
-
-    public ZipitdaException(ErrorType errorType, Map<String, Object> parameters, Consumer<String> logConsumer, Exception exception) {
+    public ZipitdaException(ErrorType errorType, Consumer<String> logConsumer, Exception e) {
+        super(errorType.getMessage());
         this.errorType = errorType;
-        this.parameters = parameters;
+        this.parameters = null;
         this.logConsumer = logConsumer;
-        this.exception = exception;
+        this.exception = e;
     }
 }

--- a/src/main/java/com/danahub/zipitda/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/danahub/zipitda/common/security/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.danahub.zipitda.common.security;
+
+import com.danahub.zipitda.user.domain.User;
+import com.danahub.zipitda.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+                .map(user -> org.springframework.security.core.userdetails.User.builder()
+                        .username(user.getEmail())
+                        .password(user.getPassword())
+                        .roles("USER")
+                        .build())
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+    }
+}

--- a/src/main/java/com/danahub/zipitda/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/danahub/zipitda/common/security/CustomUserDetailsService.java
@@ -1,5 +1,7 @@
 package com.danahub.zipitda.common.security;
 
+import com.danahub.zipitda.common.exception.ErrorType;
+import com.danahub.zipitda.common.exception.ZipitdaException;
 import com.danahub.zipitda.user.domain.User;
 import com.danahub.zipitda.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +9,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ public class CustomUserDetailsService implements UserDetailsService {
                         .password(user.getPassword())
                         .roles("USER")
                         .build())
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+                .orElseThrow(() -> new ZipitdaException(ErrorType.USER_NOT_FOUND,
+                                                        Map.of("email", email)));
     }
 }

--- a/src/main/java/com/danahub/zipitda/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/danahub/zipitda/common/security/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.stereotype.Component;
@@ -14,6 +15,7 @@ import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
@@ -32,7 +34,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
+            String extractedToken = bearerToken.substring(7).trim(); // 앞뒤 공백 제거
+            log.info("[추출된 JWT]: {}", extractedToken);
+            return extractedToken;
         }
         return null;
     }

--- a/src/main/java/com/danahub/zipitda/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/danahub/zipitda/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,39 @@
+package com.danahub.zipitda.common.security;
+
+import com.danahub.zipitda.common.util.JwtProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+        if (token != null && jwtProvider.validateToken(token)) {
+            SecurityContextHolder.getContext().setAuthentication(jwtProvider.getAuthentication(token));
+        }
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/danahub/zipitda/common/util/JwtProvider.java
+++ b/src/main/java/com/danahub/zipitda/common/util/JwtProvider.java
@@ -2,10 +2,17 @@ package com.danahub.zipitda.common.util;
 
 import com.danahub.zipitda.common.exception.ErrorType;
 import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.nimbusds.jwt.JWT;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -13,11 +20,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 @Component
+@RequiredArgsConstructor
 public class JwtProvider {
 
     private final SecretKey secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
     private final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 30; // 30분
     private final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; // 7일
+
+    private final UserDetailsService userDetailsService;
 
     public String generateAccessToken(String email) {
         return Jwts.builder()
@@ -53,5 +63,26 @@ public class JwtProvider {
         } catch (Exception e) {
             throw new ZipitdaException(ErrorType.INVALID_TOKEN);
         }
+    }
+
+
+    // JWT 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true; // 토큰이 유효함
+        } catch (ExpiredJwtException e) {
+            throw new ZipitdaException(ErrorType.TOKEN_EXPIRED);
+        } catch (IllegalArgumentException e) {
+            throw new ZipitdaException(ErrorType.INVALID_TOKEN);
+        }
+    }
+
+
+    // Spring Security Authentication 객체 생성
+    public Authentication getAuthentication(String token) {
+        String email = getEmailFromToken(token);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 }

--- a/src/main/java/com/danahub/zipitda/common/util/JwtProvider.java
+++ b/src/main/java/com/danahub/zipitda/common/util/JwtProvider.java
@@ -2,13 +2,11 @@ package com.danahub.zipitda.common.util;
 
 import com.danahub.zipitda.common.exception.ErrorType;
 import com.danahub.zipitda.common.exception.ZipitdaException;
-import com.nimbusds.jwt.JWT;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,73 +14,105 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Date;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtProvider {
 
-    private final SecretKey secretKey = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+    private final UserDetailsService userDetailsService;
     private final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 30; // 30분
     private final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; // 7일
+    private SecretKey secretKey;
 
-    private final UserDetailsService userDetailsService;
+    @Value("${jwt.secret}")
+    public void setSecretKey(String secret) {
+        log.info("JWT SecretKey 설정 완료");
+        this.secretKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
+    }
 
     public String generateAccessToken(String email) {
-        return Jwts.builder()
+        String token = Jwts.builder()
                 .setSubject(email)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION))
-                .signWith(secretKey)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
+        log.info("Access Token 생성: {}", token);
+        return token;
     }
 
     public String generateRefreshToken(String email) {
-        return Jwts.builder()
+        String token = Jwts.builder()
                 .setSubject(email)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION))
-                .signWith(secretKey)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
+        log.info("Refresh Token 생성: {}", token);
+        return token;
     }
 
+    /**
+     * JWT 파싱하여 Claims 반환
+     */
     public Claims parseToken(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-    }
-
-
-    // JWT에서 이메일 추출
-    public String getEmailFromToken(String token) {
         try {
-            return parseToken(token).getSubject(); // 토큰의 subject(email) 반환
-        } catch (Exception e) {
-            throw new ZipitdaException(ErrorType.INVALID_TOKEN);
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            log.info("JWT 파싱 성공: {}", claims);
+            return claims;
+        } catch (ExpiredJwtException e) {
+            throw new ZipitdaException(ErrorType.TOKEN_EXPIRED, Map.of("token", token), log::warn, e);
+        } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            throw new ZipitdaException(ErrorType.INVALID_TOKEN, Map.of("token", token), log::warn, e);
         }
     }
 
+    /**
+     * JWT에서 이메일 추출
+     */
+    public String getEmailFromToken(String token) {
+        try {
+            String email = parseToken(token).getSubject();
+            log.info("JWT에서 이메일 추출: {}", email);
+            return email;
+        } catch (Exception e) {
+            throw new ZipitdaException(ErrorType.INVALID_TOKEN, Map.of("token", token), log::warn, e);
+        }
+    }
 
-    // JWT 유효성 검사
+    /**
+     * JWT 유효성 검사
+     */
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
-            return true; // 토큰이 유효함
+            return true;
         } catch (ExpiredJwtException e) {
-            throw new ZipitdaException(ErrorType.TOKEN_EXPIRED);
-        } catch (IllegalArgumentException e) {
-            throw new ZipitdaException(ErrorType.INVALID_TOKEN);
+            throw new ZipitdaException(ErrorType.TOKEN_EXPIRED, Map.of("만료된 token", token), log::warn, e);
+        } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            throw new ZipitdaException(ErrorType.TOKEN_EXPIRED, Map.of("유효하지 않은 token", token), log::warn, e);
         }
     }
 
-
-    // Spring Security Authentication 객체 생성
+    /**
+     * Spring Security Authentication 객체 생성
+     */
     public Authentication getAuthentication(String token) {
-        String email = getEmailFromToken(token);
-        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        try {
+            String email = getEmailFromToken(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+            log.info("인증 객체 생성 완료: {}", email);
+            return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        } catch (Exception e) {
+            throw new ZipitdaException(ErrorType.INVALID_TOKEN, log::warn, e);
+        }
     }
 }

--- a/src/main/java/com/danahub/zipitda/community/controller/ImageController.java
+++ b/src/main/java/com/danahub/zipitda/community/controller/ImageController.java
@@ -1,0 +1,33 @@
+package com.danahub.zipitda.community.controller;
+
+import com.danahub.zipitda.common.dto.CommonResponse;
+import com.danahub.zipitda.community.dto.ImageUploadRequestDto;
+import com.danahub.zipitda.community.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/community/images")
+@RequiredArgsConstructor
+@Tag(name = "Image", description = "이미지 관리 API")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    @Operation(summary = "이미지 업로드 API", description = "이미지를 업로드하고 URL을 반환합니다.")
+    public CommonResponse<String> uploadImage(@Valid @ModelAttribute ImageUploadRequestDto requestDto) {
+        return CommonResponse.success(imageService.uploadImage(requestDto));
+    }
+
+    @DeleteMapping("/{imageId}")
+    @Operation(summary = "이미지 삭제 API", description = "사용자가 업로드한 이미지를 삭제합니다.")
+    public CommonResponse<Void> deleteImage(@PathVariable Long imageId) {
+        imageService.deleteImage(imageId);
+        return CommonResponse.success();
+    }
+}

--- a/src/main/java/com/danahub/zipitda/community/controller/PostController.java
+++ b/src/main/java/com/danahub/zipitda/community/controller/PostController.java
@@ -7,9 +7,12 @@ import com.danahub.zipitda.community.dto.PostResponseDto;
 import com.danahub.zipitda.community.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,10 +23,18 @@ public class PostController {
 
     private final PostService postService;
 
+    @GetMapping("/upload")
+    public String showPostUploadForm() {
+        return "card-post";
+    }
+
     @PostMapping
     @Operation(summary = "게시글 등록 API", description = "새로운 게시글을 등록합니다.")
-    public CommonResponse<Long> createPost(@RequestBody PostRequestDto requestDto) {
-        return CommonResponse.success(postService.createPost(requestDto));
+    public CommonResponse<Long> createPost(
+            Authentication authentication,  // JWT 기반 인증
+            @RequestBody @Valid PostRequestDto requestDto) {
+
+        return CommonResponse.success(postService.createPost(requestDto, authentication));
     }
 
     @GetMapping("/{postId}")

--- a/src/main/java/com/danahub/zipitda/community/domain/Image.java
+++ b/src/main/java/com/danahub/zipitda/community/domain/Image.java
@@ -1,5 +1,6 @@
 package com.danahub.zipitda.community.domain;
 
+import com.danahub.zipitda.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,23 +16,22 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @EntityListeners(AuditingEntityListener.class)
-public class Image {
+public class Image extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 이미지 ID
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private TargetType targetType; // POST / PRODUCT / REVIEW 등
 
-    @Column(nullable = false)
     private Long targetId; // 대상 ID
 
     @Column(nullable = false)
     private String imageUrl; // 이미지 URL
 
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt; // 생성일시
+    public void updateTargetInfo(Long targetId, TargetType targetType) {
+        this.targetId = targetId;
+        this.targetType = targetType;
+    }
 }

--- a/src/main/java/com/danahub/zipitda/community/dto/ImageUploadRequestDto.java
+++ b/src/main/java/com/danahub/zipitda/community/dto/ImageUploadRequestDto.java
@@ -1,0 +1,20 @@
+package com.danahub.zipitda.community.dto;
+
+import com.danahub.zipitda.community.domain.TargetType;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ImageUploadRequestDto(
+        Long imageId,
+        @NotNull(message = "사용자 ID가 필요합니다.")
+        Long userId,
+
+        @NotNull(message = "대상 ID가 필요합니다.")
+        Long targetId,
+
+        @NotNull(message = "대상 타입이 필요합니다.")
+        TargetType targetType, // POST, PRODUCT, REVIEW 등 구분을 위한 필드 추가
+
+        @NotNull(message = "이미지 파일이 필요합니다.")
+        MultipartFile file
+) {}

--- a/src/main/java/com/danahub/zipitda/community/dto/PostDetailResponseDto.java
+++ b/src/main/java/com/danahub/zipitda/community/dto/PostDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.danahub.zipitda.community.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record PostDetailResponseDto(
         Long id,
@@ -10,5 +11,6 @@ public record PostDetailResponseDto(
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         int likeCount,
-        int bookmarkCount
+        int bookmarkCount,
+        List<String> imageUrls
 ) {}

--- a/src/main/java/com/danahub/zipitda/community/dto/PostRequestDto.java
+++ b/src/main/java/com/danahub/zipitda/community/dto/PostRequestDto.java
@@ -2,11 +2,12 @@ package com.danahub.zipitda.community.dto;
 
 import jakarta.validation.constraints.*;
 
+import java.util.List;
+
 public record PostRequestDto(
 
         Long postId,
 
-        @NotNull(message = "사용자 ID는 필수입니다.")
         Long userId,
 
         @NotBlank(message = "제목을 입력해야 합니다.")
@@ -15,5 +16,6 @@ public record PostRequestDto(
 
         @NotBlank(message = "내용을 입력해야 합니다.")
         @Size(max = 2000, message = "내용은 최대 2000자까지 입력 가능합니다.")
-        String content
+        String content,
+        List<String> imageUrls // 등록할 이미지 URL 목록
 ) { }

--- a/src/main/java/com/danahub/zipitda/community/repository/ImageRepository.java
+++ b/src/main/java/com/danahub/zipitda/community/repository/ImageRepository.java
@@ -1,0 +1,16 @@
+package com.danahub.zipitda.community.repository;
+
+import com.danahub.zipitda.community.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    // 여러 개의 이미지 URL을 기준으로 이미지 리스트 조회
+    List<Image> findByImageUrlIn(List<String> imageUrls);
+
+    // 특정 postId의 이미지 조회
+    List<Image> findByTargetId(Long postId);
+
+}

--- a/src/main/java/com/danahub/zipitda/community/service/ImageService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/ImageService.java
@@ -1,0 +1,93 @@
+package com.danahub.zipitda.community.service;
+
+import com.danahub.zipitda.common.exception.ErrorType;
+import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.danahub.zipitda.community.domain.Image;
+import com.danahub.zipitda.community.domain.Post;
+import com.danahub.zipitda.community.domain.TargetType;
+import com.danahub.zipitda.community.dto.ImageUploadRequestDto;
+import com.danahub.zipitda.community.repository.ImageRepository;
+import com.danahub.zipitda.community.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImageService {
+    private final ImageRepository imageRepository;
+    private final PostRepository postRepository;
+    private final StorageService storageService;
+
+    public String uploadImage(ImageUploadRequestDto requestDto) {
+
+        log.debug("업로드 요청: targetType={}, targetId={}, file={}",
+                requestDto.targetType(), requestDto.targetId(), requestDto.file().getOriginalFilename());
+
+        String imageUrl = storageService.uploadFile(requestDto.file());
+
+        Image image = Image.builder()
+                .targetType(requestDto.targetType())
+                .targetId(requestDto.targetId())
+                .imageUrl(imageUrl)
+                .build();
+
+        imageRepository.save(image);
+        return imageUrl;
+    }
+
+    // 이미지 업로드 후 암호화된 URL 반환
+    public String uploadImage(MultipartFile file) {
+        log.debug("이미지 업로드 요청: {}", file.getOriginalFilename());
+
+        String encryptedUrl = storageService.uploadFile(file);
+
+        Image image = Image.builder()
+                .targetType(null)  // 일단 targetId, targetType null로 설정
+                .targetId(null)
+                .imageUrl(encryptedUrl)
+                .build();
+
+        imageRepository.save(image);
+        return encryptedUrl;
+    }
+
+    // 포스트 등록 시 해당 포스트의 이미지 targetInfo 업데이트
+    public void updateImageTargetInfo(Long postId, List<String> imageUrls, TargetType targetType) {
+        List<Image> images = imageRepository.findByImageUrlIn(imageUrls);
+
+        if (images.isEmpty()) {
+            log.warn("업데이트할 이미지가 없습니다. postId={}, imageUrls={}", postId, imageUrls);
+            return;
+        }
+
+        images.forEach(image -> {
+            image.setTargetId(postId);
+            image.setTargetType(targetType);
+        });
+
+        imageRepository.saveAll(images);
+        log.info("이미지 targetId 및 targetType 업데이트 완료: postId={}, targetType={}", postId, targetType);
+    }
+
+    public void deleteImage(Long imageId) {
+        Image image = imageRepository.findById(imageId)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
+
+        // 권한 체크: 요청한 userId와 게시글 작성자의 userId 비교
+        Post post = postRepository.findById(image.getTargetId())
+                .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
+
+        if (!post.getUserId().equals(imageId)) {
+            throw new ZipitdaException(ErrorType.ACCESS_DENIED, Map.of("message", "해당 이미지를 삭제할 권한이 없습니다."));
+        }
+
+        storageService.deleteFile(image.getImageUrl());
+        imageRepository.delete(image);
+    }
+}

--- a/src/main/java/com/danahub/zipitda/community/service/PostService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/PostService.java
@@ -4,45 +4,72 @@ import com.danahub.zipitda.common.aop.PostAuthorizationCheck;
 import com.danahub.zipitda.common.exception.ErrorType;
 import com.danahub.zipitda.common.exception.ZipitdaException;
 import com.danahub.zipitda.community.domain.Post;
+import com.danahub.zipitda.community.domain.TargetType;
+import com.danahub.zipitda.community.domain.Image;
 import com.danahub.zipitda.community.dto.PostDetailResponseDto;
 import com.danahub.zipitda.community.dto.PostRequestDto;
 import com.danahub.zipitda.community.dto.PostResponseDto;
+import com.danahub.zipitda.community.repository.ImageRepository;
 import com.danahub.zipitda.community.repository.PostRepository;
+import com.danahub.zipitda.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
 
     private final PostRepository postRepository;
+    private final ImageRepository imageRepository;
+
+    private final ImageService imageService;
+    private final UserService userService;
 
     // 게시글 생성
-    @Transactional
-    public Long createPost(@Valid PostRequestDto requestDto) {
+    public Long createPost(@Valid PostRequestDto requestDto, Authentication authentication) {
+        // JWT에서 사용자 이메일 추출
+        String userEmail = authentication.getName();
+
+        // 이메일을 기반으로 userId 조회 (유저 서비스 필요)
+        Long userId = userService.findUserIdByEmail(userEmail);
 
         Post post = Post.builder()
-                .userId(requestDto.userId())
+                .userId(userId)
                 .title(requestDto.title())
                 .content(requestDto.content())
                 .build();
-        return postRepository.save(post).getId();
+
+        Long postId = postRepository.save(post).getId();
+
+        // 등록된 postId를 이미지 targetId로 업데이트
+        if (requestDto.imageUrls() != null && !requestDto.imageUrls().isEmpty()) {
+            imageService.updateImageTargetInfo(postId, requestDto.imageUrls(), TargetType.POST);
+        }
+
+        return postId;
     }
 
     // 게시글 상세 조회
-    @Transactional(readOnly = true)
     public PostDetailResponseDto getPostDetail(Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
 
         int likeCount = postRepository.countLikesByPostId(postId);
         int bookmarkCount = postRepository.countBookmarksByPostId(postId);
+
+        // 해당 postId의 이미지 리스트 조회
+        List<String> imageUrls = imageRepository.findByTargetId(postId)
+                .stream()
+                .map(Image::getImageUrl)
+                .toList();
 
         return new PostDetailResponseDto(
                 post.getId(),
@@ -52,12 +79,12 @@ public class PostService {
                 post.getCreatedAt(),
                 post.getUpdatedAt(),
                 likeCount,
-                bookmarkCount
+                bookmarkCount,
+                imageUrls  // 이미지 리스트 추가
         );
     }
 
     // 전체 게시글 조회 (페이징 + 정렬)
-    @Transactional(readOnly = true)
     public Page<PostResponseDto> getAllPosts(Pageable pageable, String sortBy) {
         Sort sort = switch (sortBy) {
             case "likes" -> Sort.by(Sort.Order.desc("likeCount"));
@@ -79,7 +106,6 @@ public class PostService {
 
     // 게시글 수정
     @PostAuthorizationCheck
-    @Transactional
     public void updatePost(PostRequestDto requestDto) {
         Post post = postRepository.findById(requestDto.postId())
                 .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
@@ -88,13 +114,13 @@ public class PostService {
         post.setContent(requestDto.content());
     }
 
-    // ✅ 게시글 삭제 (권한 체크는 AOP에서 처리)
+    // 게시글 삭제
     @PostAuthorizationCheck
-    @Transactional
     public void deletePost(PostRequestDto requestDto) {
         postRepository.deleteById(requestDto.postId());
     }
-/*
+
+    /*
     // 게시글 검증
     private void validatePostRequest(PostRequestDto requestDto) {
         if (requestDto.title() == null || requestDto.title().isBlank()) {

--- a/src/main/java/com/danahub/zipitda/community/service/StorageService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/StorageService.java
@@ -3,6 +3,7 @@ package com.danahub.zipitda.community.service;
 import com.danahub.zipitda.common.exception.ErrorType;
 import com.danahub.zipitda.common.exception.ZipitdaException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -13,6 +14,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StorageService {
 
     private static final String UPLOAD_DIR = "src/main/resources/static/uploads/";
@@ -28,8 +30,8 @@ public class StorageService {
             file.transferTo(destinationFile);
         } catch (Exception e) {
             throw new ZipitdaException(ErrorType.INTERNAL_SERVER_ERROR,
-                                        Map.of("fileName", fileName, "originalFileName", file.getOriginalFilename()),
-                                        log -> System.err.println(log),
+                                        Map.of("fileName", fileName, "originalFileName", file.getOriginalFilename())
+                                        ,log::warn,
                                         e);
         }
 
@@ -42,21 +44,21 @@ public class StorageService {
         File file = new File(filePath);
 
         if (file.exists() && file.delete()) {
-            System.out.println("파일 삭제 완료: " + filePath);
+            log.info("파일 삭제 완료: " + filePath);
         } else {
-            throw new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND, Map.of("message", "삭제할 파일이 존재하지 않습니다."));
+            throw new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND, Map.of("filePath", filePath));
         }
     }
 
     // 파일 검증 (확장자 체크)
     private void validateFile(MultipartFile file) {
         if (file.isEmpty()) {
-            throw new ZipitdaException(ErrorType.INVALID_REQUEST, Map.of("message", "업로드할 파일이 없습니다."));
+            throw new ZipitdaException(ErrorType.INVALID_REQUEST);
         }
 
         String fileName = file.getOriginalFilename();
         if (fileName == null || !fileName.matches(".*\\.(png|jpg|jpeg|gif|bmp)$")) {
-            throw new ZipitdaException(ErrorType.UNSUPPORTED_REQUEST_TYPE, Map.of("message", "지원하지 않는 파일 형식입니다."));
+            throw new ZipitdaException(ErrorType.UNSUPPORTED_REQUEST_TYPE, Map.of("fileName", fileName));
         }
     }
 }

--- a/src/main/java/com/danahub/zipitda/community/service/StorageService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/StorageService.java
@@ -8,7 +8,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.Base64;
 import java.util.Map;
 import java.util.UUID;
 
@@ -17,25 +21,41 @@ import java.util.UUID;
 @Slf4j
 public class StorageService {
 
-    private static final String UPLOAD_DIR = "src/main/resources/static/uploads/";
+    // JAR 외부 디렉토리에 저장하기 위해 프로젝트 루트 디렉토리에 uploads 폴더 사용
+    private static final String UPLOAD_DIR = "uploads/";
 
     // 파일 저장
     public String uploadFile(MultipartFile file) {
         validateFile(file);
 
-        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
-        File destinationFile = Paths.get(UPLOAD_DIR, fileName).toFile();
-
-        try {
-            file.transferTo(destinationFile);
-        } catch (Exception e) {
-            throw new ZipitdaException(ErrorType.INTERNAL_SERVER_ERROR,
-                                        Map.of("fileName", fileName, "originalFileName", file.getOriginalFilename())
-                                        ,log::warn,
-                                        e);
+        // 업로드 폴더 존재 여부 확인 후 생성
+        File uploadDir = new File(UPLOAD_DIR);
+        if (!uploadDir.exists()) {
+            boolean created = uploadDir.mkdirs();
+            if (created) {
+                log.info(" 업로드 디렉터리 생성: {}", uploadDir.getAbsolutePath());
+            } else {
+                throw new ZipitdaException(ErrorType.INTERNAL_SERVER_ERROR, Map.of("message", "업로드 디렉터리 생성 실패"));
+            }
         }
 
-        return "/uploads/" + fileName; // 저장된 파일의 URL 반환
+        // 파일 확장자 유지 + UUID 파일명 적용 (한글 파일명 방지)
+        String originalFilename = file.getOriginalFilename();
+        String fileExtension = originalFilename.substring(originalFilename.lastIndexOf(".")); // 확장자 추출
+        String safeFileName = UUID.randomUUID().toString() + fileExtension; // 한글 파일명 제거
+        File destinationFile = new File(uploadDir, safeFileName);
+
+        // 파일 저장 (transferTo -> FileOutputStream)
+        try (FileOutputStream fos = new FileOutputStream(destinationFile)) {
+            fos.write(file.getBytes());
+            log.info("파일 업로드 성공: {}", safeFileName);
+        } catch (IOException e) {
+            throw new ZipitdaException(ErrorType.INTERNAL_SERVER_ERROR,
+                    Map.of("fileName", safeFileName, "originalFileName", originalFilename), log::warn, e);
+        }
+
+        //  암호화된 URL 반환
+        return encryptUrl("/uploads/" + safeFileName);
     }
 
     // 파일 삭제
@@ -44,7 +64,7 @@ public class StorageService {
         File file = new File(filePath);
 
         if (file.exists() && file.delete()) {
-            log.info("파일 삭제 완료: " + filePath);
+            log.info("파일 삭제 완료: {}", filePath);
         } else {
             throw new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND, Map.of("filePath", filePath));
         }
@@ -53,12 +73,17 @@ public class StorageService {
     // 파일 검증 (확장자 체크)
     private void validateFile(MultipartFile file) {
         if (file.isEmpty()) {
-            throw new ZipitdaException(ErrorType.INVALID_REQUEST);
+            throw new ZipitdaException(ErrorType.INVALID_REQUEST, Map.of("message", "파일이 비어 있습니다."));
         }
 
         String fileName = file.getOriginalFilename();
         if (fileName == null || !fileName.matches(".*\\.(png|jpg|jpeg|gif|bmp)$")) {
-            throw new ZipitdaException(ErrorType.UNSUPPORTED_REQUEST_TYPE, Map.of("fileName", fileName));
+            throw new ZipitdaException(ErrorType.UNSUPPORTED_REQUEST_TYPE, Map.of("fileName", fileName, "message", "지원하지 않는 파일 형식입니다."));
         }
+    }
+
+    // 파일 URL 암호화
+    private String encryptUrl(String url) {
+        return Base64.getEncoder().encodeToString(url.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/danahub/zipitda/config/SecurityConfig.java
+++ b/src/main/java/com/danahub/zipitda/config/SecurityConfig.java
@@ -23,6 +23,7 @@ public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
     private final CustomUserDetailsService userDetailsService;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter; //
 
     @Bean
     public AuthenticationManager authenticationManager() {
@@ -45,7 +46,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/login", "/api/users/register").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class); //
 
         return http.build();
     }

--- a/src/main/java/com/danahub/zipitda/config/SecurityConfig.java
+++ b/src/main/java/com/danahub/zipitda/config/SecurityConfig.java
@@ -6,11 +6,13 @@ import com.danahub.zipitda.common.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -42,9 +44,17 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/users/register").permitAll()
-                        .anyRequest().authenticated()
+                        .requestMatchers(
+                                "/api/auth/login",
+                                "/api/users/register",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/community/posts/**").permitAll()
+                        .requestMatchers("/error").permitAll()
+                        .anyRequest().permitAll() // TODO 테스트 완료하고 filterChain 점검할 것
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class); //
 

--- a/src/main/java/com/danahub/zipitda/config/SecurityConfig.java
+++ b/src/main/java/com/danahub/zipitda/config/SecurityConfig.java
@@ -1,14 +1,36 @@
 package com.danahub.zipitda.config;
 
+import com.danahub.zipitda.common.security.CustomUserDetailsService;
+import com.danahub.zipitda.common.security.JwtAuthenticationFilter;
+import com.danahub.zipitda.common.util.JwtProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return new ProviderManager(provider);
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -18,11 +40,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable()) // CSRF 비활성화
+                .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll() // 모든 요청 인증 없이 허용 (TODO:테스트용!!이니 꼭 수정할 것)
-                );
+                        .requestMatchers("/api/auth/login", "/api/users/register").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
-
 }

--- a/src/main/java/com/danahub/zipitda/user/service/UserService.java
+++ b/src/main/java/com/danahub/zipitda/user/service/UserService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -69,5 +70,11 @@ public class UserService {
                 user.getIsActive(),
                 user.getProfileImage()
         );
+    }
+    public Long findUserIdByEmail(String userEmail) {
+        return userRepository.findByEmail(userEmail)
+                .map(User::getId)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.USER_NOT_FOUND,
+                        Map.of("userEmail", userEmail)));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,3 +67,6 @@ kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 # Naver OAuth ??
 naver.client-id=your_naver_client_id
 naver.redirect-uri=http://localhost:8081/social-login/naver/callback
+
+# JWT
+jwt.secret=3b249c1f7edfea8a99b5f5ada4e73659fe6e282f12b60c3cba9d0e0593ebc366


### PR DESCRIPTION
- Spring Security 적용
  - JwtAuthenticationFilter를 OncePerRequestFilter로 변경하여 요청마다 한 번만 JWT 검증 수행
  - SecurityConfig에서 UsernamePasswordAuthenticationFilter 앞에 JwtAuthenticationFilter를 추가
  - CustomUserDetailsService를 활용하여 인증 정보 로드
- 로그인한 유저 정보 조회 시 인증 방식 변경
  - 기존 : AuthService#getUserInfo(String jwtToken)에서 JWT 직접 검증 후 이메일 추출
  - 변경 : SecurityContextHolder에서 Authentication 객체를 가져와 이메일 사용
- JWT Provider 개선
  - getUserInfo()가 토큰을 직접 검증하지 않고, SecurityContext에서 가져오도록 변경
- ZipitdaException 사용 확장
  - Exception 필드 및 생성자 추가
Closes #43  #44  