### PR TITLE
[#46] 상품 CRUD 기능 추가

### DIFF
--- a/src/main/java/com/danahub/zipitda/product/controller/ProductController.java
+++ b/src/main/java/com/danahub/zipitda/product/controller/ProductController.java
@@ -1,0 +1,50 @@
+package com.danahub.zipitda.product.controller;
+
+import com.danahub.zipitda.common.dto.CommonResponse;
+import com.danahub.zipitda.product.dto.ProductDetailResponseDto;
+import com.danahub.zipitda.product.dto.ProductRequestDto;
+import com.danahub.zipitda.product.dto.ProductResponseDto;
+import com.danahub.zipitda.product.service.ProductService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    @PostMapping
+    public CommonResponse<Long> createProduct(
+            Authentication authentication,
+            @RequestBody @Valid ProductRequestDto requestDto) {
+        return CommonResponse.success(productService.createProduct(requestDto, authentication));
+    }
+
+    @GetMapping
+    public CommonResponse<Page<ProductResponseDto>> getAllProducts(Pageable pageable) {
+        return CommonResponse.success(productService.getAllProducts(pageable));
+    }
+
+    @GetMapping("/{productId}")
+    public CommonResponse<ProductDetailResponseDto> getProductDetail(@PathVariable Long productId) {
+        return CommonResponse.success(productService.getProductDetail(productId));
+    }
+
+    @PutMapping("/{productId}")
+    public CommonResponse<Void> updateProduct(@PathVariable Long productId, @RequestBody ProductRequestDto requestDto) {
+        productService.updateProduct(productId, requestDto);
+        return CommonResponse.success();
+    }
+
+    @DeleteMapping("/{productId}")
+    public CommonResponse<Void> deleteProduct(@PathVariable Long productId) {
+        productService.deleteProduct(productId);
+        return CommonResponse.success();
+    }
+}

--- a/src/main/java/com/danahub/zipitda/product/domain/Product.java
+++ b/src/main/java/com/danahub/zipitda/product/domain/Product.java
@@ -1,0 +1,29 @@
+package com.danahub.zipitda.product.domain;
+
+import com.danahub.zipitda.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "products")
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;  // 상품 ID
+
+    private Long userId;  // 등록한 사용자 ID
+    private String name;  // 상품명
+    private String description;  // 상품 설명
+    private String category;  // 카테고리
+    private Long price;  // 상품 가격
+    private Long stockQuantity;  // 재고 수량
+
+}

--- a/src/main/java/com/danahub/zipitda/product/dto/ProductDetailResponseDto.java
+++ b/src/main/java/com/danahub/zipitda/product/dto/ProductDetailResponseDto.java
@@ -1,0 +1,17 @@
+package com.danahub.zipitda.product.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ProductDetailResponseDto(
+        Long id,
+        Long userId,
+        String name,
+        String description,
+        String category,
+        Long price,
+        Long stockQuantity,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        List<String> imageUrls
+) {}

--- a/src/main/java/com/danahub/zipitda/product/dto/ProductRequestDto.java
+++ b/src/main/java/com/danahub/zipitda/product/dto/ProductRequestDto.java
@@ -1,0 +1,18 @@
+package com.danahub.zipitda.product.dto;
+
+import jakarta.validation.constraints.*;
+import java.util.List;
+
+public record ProductRequestDto(
+        @NotBlank(message = "상품명을 입력하세요.")
+        String name,
+        @NotBlank(message = "상품 설명을 입력하세요.")
+        String description,
+        @NotBlank(message = "카테고리를 입력하세요.")
+        String category,
+        @NotNull(message = "가격을 입력하세요.")
+        @Positive Long price,
+        @NotNull(message = "재고 수량을 입력하세요.")
+        @PositiveOrZero Long stockQuantity,
+        List<String> imageUrls
+) {}

--- a/src/main/java/com/danahub/zipitda/product/dto/ProductResponseDto.java
+++ b/src/main/java/com/danahub/zipitda/product/dto/ProductResponseDto.java
@@ -1,0 +1,12 @@
+package com.danahub.zipitda.product.dto;
+
+import java.time.LocalDateTime;
+
+public record ProductResponseDto(
+        Long id,
+        String name,
+        String category,
+        Long price,
+        Long stockQuantity,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/danahub/zipitda/product/repository/ProductRepository.java
+++ b/src/main/java/com/danahub/zipitda/product/repository/ProductRepository.java
@@ -1,0 +1,10 @@
+package com.danahub.zipitda.product.repository;
+
+import com.danahub.zipitda.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+}

--- a/src/main/java/com/danahub/zipitda/product/service/ProductService.java
+++ b/src/main/java/com/danahub/zipitda/product/service/ProductService.java
@@ -1,0 +1,109 @@
+package com.danahub.zipitda.product.service;
+
+import com.danahub.zipitda.common.exception.ErrorType;
+import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.danahub.zipitda.community.domain.TargetType;
+import com.danahub.zipitda.community.repository.ImageRepository;
+import com.danahub.zipitda.community.service.ImageService;
+import com.danahub.zipitda.product.domain.Product;
+import com.danahub.zipitda.product.dto.ProductRequestDto;
+import com.danahub.zipitda.product.dto.ProductResponseDto;
+import com.danahub.zipitda.product.dto.ProductDetailResponseDto;
+import com.danahub.zipitda.product.repository.ProductRepository;
+import com.danahub.zipitda.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+    private final ImageRepository imageRepository;
+    private final ImageService imageService;
+    private final UserService userService;
+
+    // 상품 등록
+    public Long createProduct(ProductRequestDto requestDto, Authentication authentication) {
+        Long userId = userService.findUserIdByEmail(authentication.getName());
+
+        Product product = Product.builder()
+                .userId(userId)
+                .name(requestDto.name())
+                .description(requestDto.description())
+                .category(requestDto.category())
+                .price(requestDto.price())
+                .stockQuantity(requestDto.stockQuantity())
+                .build();
+
+        Long productId = productRepository.save(product).getId();
+
+        // 이미지 저장
+        if (requestDto.imageUrls() != null && !requestDto.imageUrls().isEmpty()) {
+            imageService.updateImageTargetInfo(productId, requestDto.imageUrls(), TargetType.PRODUCT);
+        }
+
+        return productId;
+    }
+
+    // 상품 목록 조회 (페이징)
+    public Page<ProductResponseDto> getAllProducts(Pageable pageable) {
+        return productRepository.findAll(pageable)
+                .map(product -> new ProductResponseDto(
+                        product.getId(),
+                        product.getName(),
+                        product.getCategory(),
+                        product.getPrice(),
+                        product.getStockQuantity(),
+                        product.getCreatedAt()
+                ));
+    }
+
+    // 상품 상세 조회
+    public ProductDetailResponseDto getProductDetail(Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
+
+        // 이미지 조회
+        List<String> imageUrls = imageRepository.findByTargetId(productId)
+                .stream()
+                .map(image -> image.getImageUrl())
+                .toList();
+
+        return new ProductDetailResponseDto(
+                product.getId(),
+                product.getUserId(),
+                product.getName(),
+                product.getDescription(),
+                product.getCategory(),
+                product.getPrice(),
+                product.getStockQuantity(),
+                product.getCreatedAt(),
+                product.getUpdatedAt(),
+                imageUrls
+        );
+    }
+
+    // 상품 수정
+    public void updateProduct(Long productId, ProductRequestDto requestDto) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
+
+        product.setName(requestDto.name());
+        product.setDescription(requestDto.description());
+        product.setCategory(requestDto.category());
+        product.setPrice(requestDto.price());
+        product.setStockQuantity(requestDto.stockQuantity());
+
+        productRepository.save(product);
+    }
+
+    // 상품 삭제
+    public void deleteProduct(Long productId) {
+        productRepository.deleteById(productId);
+    }
+}


### PR DESCRIPTION
1. 상품 등록 API (POST /api/products)
- 사용자가 상품을 등록할 수 있도록 한다.
- 상품 등록 시 JWT 인증이 필요
- 상품과 관련된 이미지 함께 저장
2. 상품 목록 조회 API (GET /api/products)
- 등록된 모든 상품을 조회
- 기본적으로 최신순 정렬 반환 
- 상품 목록에는 이름, 가격, 카테고리, 이미지 썸네일 정보가 포함 
3. 상품 상세 조회 API (GET /api/products/{productId})
- 특정 상품의 상세 정보를 조회
- 상품명, 설명, 카테고리, 가격, 재고 수량, 이미지 목록을 포함
4. 상품 삭제 API (DELETE /api/products/{productId})
- 등록된 상품 삭제
- 상품 삭제 시, 해당 상품과 관련된 이미지도 함께 삭제
- 본인이 등록한 상품만 삭제 가능하도록 한다. (JWT 인증)