### PR TITLE
[#59] POST, IMAGE 수정 삭제시 인증 로직 변경

### DIFF
--- a/src/main/java/com/danahub/zipitda/common/security/CustomUserDetails.java
+++ b/src/main/java/com/danahub/zipitda/common/security/CustomUserDetails.java
@@ -1,0 +1,52 @@
+package com.danahub.zipitda.common.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Long userId;
+    private final String email;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(Long userId, String email, String password, Collection<? extends GrantedAuthority> authorities) {
+        this.userId = userId;
+        this.email = email;
+        this.password = password;
+        this.authorities = authorities;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/danahub/zipitda/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/danahub/zipitda/common/security/CustomUserDetailsService.java
@@ -2,7 +2,6 @@ package com.danahub.zipitda.common.security;
 
 import com.danahub.zipitda.common.exception.ErrorType;
 import com.danahub.zipitda.common.exception.ZipitdaException;
-import com.danahub.zipitda.user.domain.User;
 import com.danahub.zipitda.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -11,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -21,11 +21,12 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         return userRepository.findByEmail(email)
-                .map(user -> org.springframework.security.core.userdetails.User.builder()
-                        .username(user.getEmail())
-                        .password(user.getPassword())
-                        .authorities(new SimpleGrantedAuthority(user.getRole()))
-                        .build())
+                .map(user -> new CustomUserDetails(
+                        user.getId(),  // userId 포함
+                        user.getEmail(),
+                        user.getPassword(),
+                        List.of(new SimpleGrantedAuthority(user.getRole()))
+                ))
                 .orElseThrow(() -> new ZipitdaException(ErrorType.USER_NOT_FOUND, Map.of("email", email)));
     }
 }

--- a/src/main/java/com/danahub/zipitda/common/util/JwtProvider.java
+++ b/src/main/java/com/danahub/zipitda/common/util/JwtProvider.java
@@ -2,6 +2,7 @@ package com.danahub.zipitda.common.util;
 
 import com.danahub.zipitda.common.exception.ErrorType;
 import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.danahub.zipitda.common.security.CustomUserDetails;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
@@ -96,7 +97,6 @@ public class JwtProvider {
 
             UserDetails userDetails = userDetailsService.loadUserByUsername(email);
 
-            log.info("인증 객체 생성 완료: {}, role: {}", email);
             return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         } catch (Exception e) {
             throw new ZipitdaException(ErrorType.INVALID_TOKEN, log::warn, e);

--- a/src/main/java/com/danahub/zipitda/community/controller/ImageController.java
+++ b/src/main/java/com/danahub/zipitda/community/controller/ImageController.java
@@ -1,12 +1,16 @@
 package com.danahub.zipitda.community.controller;
 
 import com.danahub.zipitda.common.dto.CommonResponse;
+import com.danahub.zipitda.common.security.CustomUserDetails;
 import com.danahub.zipitda.community.dto.ImageUploadRequestDto;
 import com.danahub.zipitda.community.service.ImageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,14 +24,16 @@ public class ImageController {
 
     @PostMapping
     @Operation(summary = "이미지 업로드 API", description = "이미지를 업로드하고 URL을 반환합니다.")
-    public CommonResponse<String> uploadImage(@Valid @ModelAttribute ImageUploadRequestDto requestDto) {
-        return CommonResponse.success(imageService.uploadImage(requestDto));
+    public CommonResponse<String> uploadImage(@RequestPart MultipartFile file,
+                                              @AuthenticationPrincipal CustomUserDetails user) {
+        return CommonResponse.success(imageService.uploadImage(file, user));
     }
 
-    @DeleteMapping("/{imageId}")
-    @Operation(summary = "이미지 삭제 API", description = "사용자가 업로드한 이미지를 삭제합니다.")
-    public CommonResponse<Void> deleteImage(@PathVariable Long imageId) {
-        imageService.deleteImage(imageId);
-        return CommonResponse.success();
+    @DeleteMapping
+    @Operation(summary = "이미지 삭제 API", description = "사용자가 업로드한 이미지를 삭제합니다. imageUrl은 암호화된 값 그대로 전달.")
+    public void deleteImageByUrl(@RequestParam String imageUrl,
+                                                                 @AuthenticationPrincipal CustomUserDetails user) {
+        imageService.deleteImageByUrl(imageUrl, user);
+        ResponseEntity.ok(CommonResponse.success());
     }
 }

--- a/src/main/java/com/danahub/zipitda/community/controller/PostController.java
+++ b/src/main/java/com/danahub/zipitda/community/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.danahub.zipitda.community.controller;
 
 import com.danahub.zipitda.common.dto.CommonResponse;
+import com.danahub.zipitda.common.security.CustomUserDetails;
 import com.danahub.zipitda.community.dto.PostDetailResponseDto;
 import com.danahub.zipitda.community.dto.PostRequestDto;
 import com.danahub.zipitda.community.dto.PostResponseDto;
@@ -12,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Controller;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -53,15 +54,17 @@ public class PostController {
 
     @PutMapping
     @Operation(summary = "게시글 수정 API", description = "게시글을 수정합니다.")
-    public CommonResponse<Void> updatePost(@RequestBody PostRequestDto requestDto) {
-        postService.updatePost(requestDto);
-        return CommonResponse.success();
+    public void updatePost(@RequestBody PostRequestDto requestDto,
+                           @AuthenticationPrincipal CustomUserDetails user) {
+        postService.updatePost(requestDto, user);
+        CommonResponse.success();
     }
 
-    @DeleteMapping
+    @DeleteMapping("/{postId}")
     @Operation(summary = "게시글 삭제 API", description = "게시글을 삭제합니다.")
-    public CommonResponse<Void> deletePost(@RequestBody PostRequestDto requestDto) {
-        postService.deletePost(requestDto);
-        return CommonResponse.success();
+    public void deletePost(@PathVariable Long postId,
+                           @AuthenticationPrincipal CustomUserDetails user) {
+        postService.deletePost(postId, user);
+        CommonResponse.success();
     }
 }

--- a/src/main/java/com/danahub/zipitda/community/domain/Image.java
+++ b/src/main/java/com/danahub/zipitda/community/domain/Image.java
@@ -30,6 +30,9 @@ public class Image extends BaseEntity {
     @Column(nullable = false)
     private String imageUrl; // 이미지 URL
 
+    @Column(nullable = false)
+    private Long userId;  // 등록자 ID
+
     public void updateTargetInfo(Long targetId, TargetType targetType) {
         this.targetId = targetId;
         this.targetType = targetType;

--- a/src/main/java/com/danahub/zipitda/community/repository/ImageRepository.java
+++ b/src/main/java/com/danahub/zipitda/community/repository/ImageRepository.java
@@ -4,6 +4,7 @@ import com.danahub.zipitda.community.domain.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
@@ -12,5 +13,8 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     // 특정 postId의 이미지 조회
     List<Image> findByTargetId(Long postId);
+
+    // url 기준으로 image찾기
+    Optional<Image> findByImageUrl(String imageUrl);
 
 }

--- a/src/main/java/com/danahub/zipitda/community/service/ImageService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/ImageService.java
@@ -1,16 +1,22 @@
 package com.danahub.zipitda.community.service;
 
+import com.danahub.zipitda.common.dto.CommonResponse;
 import com.danahub.zipitda.common.exception.ErrorType;
 import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.danahub.zipitda.common.security.CustomUserDetails;
 import com.danahub.zipitda.community.domain.Image;
 import com.danahub.zipitda.community.domain.Post;
 import com.danahub.zipitda.community.domain.TargetType;
 import com.danahub.zipitda.community.dto.ImageUploadRequestDto;
 import com.danahub.zipitda.community.repository.ImageRepository;
 import com.danahub.zipitda.community.repository.PostRepository;
+import com.danahub.zipitda.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -20,42 +26,10 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Slf4j
 public class ImageService {
+
     private final ImageRepository imageRepository;
-    private final PostRepository postRepository;
     private final StorageService storageService;
-
-    public String uploadImage(ImageUploadRequestDto requestDto) {
-
-        log.debug("업로드 요청: targetType={}, targetId={}, file={}",
-                requestDto.targetType(), requestDto.targetId(), requestDto.file().getOriginalFilename());
-
-        String imageUrl = storageService.uploadFile(requestDto.file());
-
-        Image image = Image.builder()
-                .targetType(requestDto.targetType())
-                .targetId(requestDto.targetId())
-                .imageUrl(imageUrl)
-                .build();
-
-        imageRepository.save(image);
-        return imageUrl;
-    }
-
-    // 이미지 업로드 후 암호화된 URL 반환
-    public String uploadImage(MultipartFile file) {
-        log.debug("이미지 업로드 요청: {}", file.getOriginalFilename());
-
-        String encryptedUrl = storageService.uploadFile(file);
-
-        Image image = Image.builder()
-                .targetType(null)  // 일단 targetId, targetType null로 설정
-                .targetId(null)
-                .imageUrl(encryptedUrl)
-                .build();
-
-        imageRepository.save(image);
-        return encryptedUrl;
-    }
+    private final UserService userService;
 
     // 포스트 등록 시 해당 포스트의 이미지 targetInfo 업데이트
     public void updateImageTargetInfo(Long postId, List<String> imageUrls, TargetType targetType) {
@@ -75,19 +49,58 @@ public class ImageService {
         log.info("이미지 targetId 및 targetType 업데이트 완료: postId={}, targetType={}", postId, targetType);
     }
 
-    public void deleteImage(Long imageId) {
+    public String uploadImage(MultipartFile file, CustomUserDetails user) {
+        log.debug("이미지 업로드 요청: {}", file.getOriginalFilename());
+
+        String encryptedUrl = storageService.uploadFile(file);
+
+        Image image = Image.builder()
+                .userId(user.getUserId())
+                .targetType(null)
+                .targetId(null)
+                .imageUrl(encryptedUrl)
+                .build();
+
+        imageRepository.save(image);
+        return encryptedUrl;
+    }
+
+    public void deleteImage(Long imageId, CustomUserDetails user) {
+
+        log.info("삭제 요청한 사용자 userId: {}", user.getUserId());
+        log.info("삭제 대상 imageId: {}", imageId);
+
         Image image = imageRepository.findById(imageId)
                 .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
 
-        // 권한 체크: 요청한 userId와 게시글 작성자의 userId 비교
-        Post post = postRepository.findById(image.getTargetId())
-                .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
+        log.info("조회된 이미지 userId: {}", image.getUserId());
 
-        if (!post.getUserId().equals(imageId)) {
-            throw new ZipitdaException(ErrorType.ACCESS_DENIED, Map.of("message", "해당 이미지를 삭제할 권한이 없습니다."));
+        if (!image.getUserId().equals(user.getUserId())) {
+            throw new ZipitdaException(ErrorType.ACCESS_DENIED, Map.of("userId", user.getUserId()));
         }
 
         storageService.deleteFile(image.getImageUrl());
         imageRepository.delete(image);
+        log.info("이미지 삭제 완료: imageId={}, userId={}", imageId, user.getUserId());
     }
+
+    public void deleteImageByUrl(String encryptedUrl, CustomUserDetails user) {
+
+        log.info("삭제 요청한 사용자 userId: {}", user.getUserId());
+        log.info("삭제 대상 imageUrl: {}", encryptedUrl);
+
+        Image image = imageRepository.findByImageUrl(encryptedUrl)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
+
+        log.info("조회된 이미지 userId: {}", image.getUserId());
+
+        if (!image.getUserId().equals(user.getUserId())) {
+            throw new ZipitdaException(ErrorType.ACCESS_DENIED, Map.of("userId", user.getUserId()));
+        }
+
+        storageService.deleteFile(image.getImageUrl());
+        imageRepository.delete(image);
+        log.info("이미지 삭제 완료: imageUrl={}, userId={}", encryptedUrl, user.getUserId());
+    }
+
 }

--- a/src/main/java/com/danahub/zipitda/community/service/PostService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/PostService.java
@@ -3,6 +3,7 @@ package com.danahub.zipitda.community.service;
 import com.danahub.zipitda.common.aop.PostAuthorizationCheck;
 import com.danahub.zipitda.common.exception.ErrorType;
 import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.danahub.zipitda.common.security.CustomUserDetails;
 import com.danahub.zipitda.community.domain.Post;
 import com.danahub.zipitda.community.domain.TargetType;
 import com.danahub.zipitda.community.domain.Image;
@@ -14,17 +15,20 @@ import com.danahub.zipitda.community.repository.PostRepository;
 import com.danahub.zipitda.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PostService {
 
     private final PostRepository postRepository;
@@ -105,29 +109,29 @@ public class PostService {
     }
 
     // 게시글 수정
-    @PostAuthorizationCheck
-    public void updatePost(PostRequestDto requestDto) {
+    public void updatePost(PostRequestDto requestDto, CustomUserDetails user) {
         Post post = postRepository.findById(requestDto.postId())
                 .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
+        if (!post.getUserId().equals(user.getUserId())) {
+            throw new ZipitdaException(ErrorType.ACCESS_DENIED);
+        }
 
         post.setTitle(requestDto.title());
         post.setContent(requestDto.content());
+        log.info("게시글 수정 완료 - postId: {}, userId: {}", post.getId(), user.getUserId());
+
     }
 
     // 게시글 삭제
-    @PostAuthorizationCheck
-    public void deletePost(PostRequestDto requestDto) {
-        postRepository.deleteById(requestDto.postId());
-    }
+    public void deletePost(Long postId, CustomUserDetails user) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
 
-    /*
-    // 게시글 검증
-    private void validatePostRequest(PostRequestDto requestDto) {
-        if (requestDto.title() == null || requestDto.title().isBlank()) {
-            throw new ZipitdaException(ErrorType.MISSING_REQUIRED_VALUE);
+        if (!post.getUserId().equals(user.getUserId())) {
+            throw new ZipitdaException(ErrorType.ACCESS_DENIED);
         }
-        if (requestDto.content() == null || requestDto.content().isBlank()) {
-            throw new ZipitdaException(ErrorType.MISSING_REQUIRED_VALUE);
-        }
-    }*/
+
+        postRepository.delete(post);
+        log.info("게시글 삭제 완료 - postId: {}, userId: {}", postId, user.getUserId());
+    }
 }

--- a/src/main/java/com/danahub/zipitda/community/service/StorageService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/StorageService.java
@@ -58,15 +58,31 @@ public class StorageService {
         return encryptUrl("/uploads/" + safeFileName);
     }
 
-    // 파일 삭제
-    public void deleteFile(String fileUrl) {
-        String filePath = UPLOAD_DIR + fileUrl.replace("/uploads/", "");
+    // 파일 삭제 - Base64 복호화 후 실제 경로로 파일 삭제
+    public void deleteFile(String encryptedUrl) {
+        String decodedUrl = decryptUrl(encryptedUrl);
+        String filePath = Paths.get(UPLOAD_DIR, decodedUrl.replace("/uploads/", "")).toString();
+
         File file = new File(filePath);
+
+        log.info("파일 삭제 시도: {}", filePath);
 
         if (file.exists() && file.delete()) {
             log.info("파일 삭제 완료: {}", filePath);
         } else {
+            log.warn("파일 삭제 실패 또는 존재하지 않음: {}", filePath);
             throw new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND, Map.of("filePath", filePath));
+        }
+    }
+
+    // 파일 URL Base64 복호화
+    private String decryptUrl(String encryptedUrl) {
+        try {
+            byte[] decodedBytes = Base64.getDecoder().decode(encryptedUrl);
+            return new String(decodedBytes, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            log.warn("URL 복호화 실패: {}", encryptedUrl);
+            throw new ZipitdaException(ErrorType.INVALID_REQUEST, Map.of("encryptedUrl", encryptedUrl), log::warn, e);
         }
     }
 


### PR DESCRIPTION
- 기존 : 서비스 로직 내에서 userId를 직접 파라미터로 전달받아 비교
- 변경 : @AuthenticationPrincipal을 통해 전달받은 CustomUserDetails에서 userId를 추출하여 검증 수행
Closes #59 