### PR TITLE
[#70] 결제 실패이력 DB에 기록하도록 수정

### DIFF
--- a/src/main/java/com/danahub/zipitda/order/service/PaymentRecordService.java
+++ b/src/main/java/com/danahub/zipitda/order/service/PaymentRecordService.java
@@ -1,0 +1,37 @@
+package com.danahub.zipitda.order.service;
+
+import com.danahub.zipitda.common.exception.ErrorType;
+import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.danahub.zipitda.order.domain.Payment;
+import com.danahub.zipitda.order.domain.PaymentStatus;
+import com.danahub.zipitda.order.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentRecordService {
+
+    private final PaymentRepository paymentRepository;
+
+    /**
+     * 결제 실패 기록을 남기는 메서드
+     * - Propagation.REQUIRES_NEW: 메인 트랜잭션과 분리해서 실행
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void failPaymentInNewTx(Long paymentId, String transactionId, String reason) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.PAYMENT_NOT_FOUND));
+
+        payment.setTransactionId(transactionId);
+        payment.setStatus(PaymentStatus.FAILED);
+        payment.setFailedReason(reason);
+        payment.setPaidAt(LocalDateTime.now());
+
+        paymentRepository.save(payment);
+    }
+}

--- a/src/main/java/com/danahub/zipitda/order/service/PaymentService.java
+++ b/src/main/java/com/danahub/zipitda/order/service/PaymentService.java
@@ -23,13 +23,19 @@ public class PaymentService {
     private final OrderRepository orderRepository;
     private final RedissonClient redissonClient;
     private final ProductRepository productRepository;
+    private final PaymentRecordService paymentRecordService;
+
     @Transactional
     public void processPaymentCallback(PaymentCallbackRequestDto dto) {
         Order order = orderRepository.findByOrderNumber(dto.orderNumber())
                 .orElseThrow(() -> new ZipitdaException(ErrorType.ORDER_NOT_FOUND));
 
         Payment payment = order.getPayment();
+        if (payment == null) {
+            throw new ZipitdaException(ErrorType.PAYMENT_NOT_FOUND);
+        }
 
+        // 재고 차감 시도
         for (OrderItem item : order.getOrderItems()) {
             Long productId = item.getProduct().getId();
             int quantity = item.getQuantity();
@@ -39,25 +45,28 @@ public class PaymentService {
                 if (lock.tryLock(5, 3, TimeUnit.SECONDS)) {
                     Product product = productRepository.findById(productId)
                             .orElseThrow(() -> {
-                                failPayment(payment, dto.transactionId(), "상품 정보 없음");
-                                return new ZipitdaException(ErrorType.PRODUCT_NOT_FOUND);
+                                // 재고 로드 실패
+                                recordFailureAndThrow(payment.getId(), dto.transactionId(), "상품 정보 없음", ErrorType.PRODUCT_NOT_FOUND);
+                                return null;
                             });
 
                     if (product.getStockQuantity() < quantity) {
-                        failPayment(payment, dto.transactionId(), "재고 부족");
-                        throw new ZipitdaException(ErrorType.OUT_OF_STOCK);
+                        // 재고 부족
+                        recordFailureAndThrow(payment.getId(), dto.transactionId(), "재고 부족", ErrorType.OUT_OF_STOCK);
                     }
 
                     product.setStockQuantity(product.getStockQuantity() - quantity);
                     productRepository.save(product);
+
                 } else {
-                    failPayment(payment, dto.transactionId(), "락 획득 실패");
-                    throw new ZipitdaException(ErrorType.LOCK_FAILED);
+                    // 락 획득 실패
+                    recordFailureAndThrow(payment.getId(), dto.transactionId(), "락 획득 실패", ErrorType.LOCK_FAILED);
                 }
+
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                failPayment(payment, dto.transactionId(), "락 인터럽트 발생");
-                throw new ZipitdaException(ErrorType.LOCK_FAILED);
+                // 인터럽트 발생
+                recordFailureAndThrow(payment.getId(), dto.transactionId(), "락 인터럽트 발생", ErrorType.LOCK_FAILED);
             } finally {
                 if (lock.isHeldByCurrentThread()) {
                     lock.unlock();
@@ -73,11 +82,11 @@ public class PaymentService {
         order.setStatus(OrderStatus.CONFIRMED);
     }
 
-    // ️결제 실패 처리 메서드
-    private void failPayment(Payment payment, String transactionId, String reason) {
-        payment.setTransactionId(transactionId);
-        payment.setStatus(PaymentStatus.FAILED);
-        payment.setFailedReason(reason);
-        payment.setPaidAt(LocalDateTime.now());
+
+    private void recordFailureAndThrow(Long paymentId, String txId, String reason, ErrorType errorType) {
+        // 결제 실패를 별도 트랜잭션에 기록
+        paymentRecordService.failPaymentInNewTx(paymentId, txId, reason);
+
+        throw new ZipitdaException(errorType);
     }
 }

--- a/src/main/java/com/danahub/zipitda/order/service/PaymentService.java
+++ b/src/main/java/com/danahub/zipitda/order/service/PaymentService.java
@@ -90,4 +90,3 @@ public class PaymentService {
         throw new ZipitdaException(errorType);
     }
 }
-정

--- a/src/main/java/com/danahub/zipitda/order/service/PaymentService.java
+++ b/src/main/java/com/danahub/zipitda/order/service/PaymentService.java
@@ -90,3 +90,4 @@ public class PaymentService {
         throw new ZipitdaException(errorType);
     }
 }
+정


### PR DESCRIPTION
- 결제 실패이력을 DB에 남겨야하기 때문에 로직 수정
  - failPayment() 호출 후, 그 부분만 별도 트랜잭션으로 묶어 DB에 저장 → 이후 ZipitdaException을 던져 메인 트랜잭션 롤백

- 두 단계로 나눠서 설계
1. 메인 서비스 – processPaymentCallback()
2. 별도 트랜잭션 서비스 – PaymentRecordService (결제 실패 기록 전용)
Closes #70 