### PR TITLE
[#35] 좋아요 기능 구현 및 동시성 대응, 중복 방지 처리 추가

### DIFF
--- a/src/main/java/com/danahub/zipitda/common/exception/ErrorType.java
+++ b/src/main/java/com/danahub/zipitda/common/exception/ErrorType.java
@@ -50,6 +50,7 @@ public enum ErrorType {
     PRODUCT_ALREADY_EXISTS(40904, HttpStatus.CONFLICT, "해당 상품이 이미 존재합니다."),
     SHIPPING_ALREADY_PROCESSED(40905, HttpStatus.CONFLICT, "배송이 이미 처리 중이거나 완료되었습니다."),
     LOCK_FAILED(40906, HttpStatus.CONFLICT, "재고 처리 중 잠금에 실패했습니다. 다시 시도해주세요."),
+    ALREADY_LIKED(40907, HttpStatus.CONFLICT, "이미 좋아요한 게시글입니다."),
 
     // 410 GONE - 리소스 만료
     VERIFICATION_EXPIRED(41000, HttpStatus.GONE, "인증 코드가 만료되었습니다."),

--- a/src/main/java/com/danahub/zipitda/community/controller/ImageController.java
+++ b/src/main/java/com/danahub/zipitda/community/controller/ImageController.java
@@ -31,8 +31,7 @@ public class ImageController {
 
     @DeleteMapping
     @Operation(summary = "이미지 삭제 API", description = "사용자가 업로드한 이미지를 삭제합니다. imageUrl은 암호화된 값 그대로 전달.")
-    public void deleteImageByUrl(@RequestParam String imageUrl,
-                                                                 @AuthenticationPrincipal CustomUserDetails user) {
+    public void deleteImageByUrl(@RequestParam String imageUrl, @AuthenticationPrincipal CustomUserDetails user) {
         imageService.deleteImageByUrl(imageUrl, user);
         ResponseEntity.ok(CommonResponse.success());
     }

--- a/src/main/java/com/danahub/zipitda/community/controller/LikeController.java
+++ b/src/main/java/com/danahub/zipitda/community/controller/LikeController.java
@@ -1,0 +1,4 @@
+package com.danahub.zipitda.community.controller;
+
+public class LikeController {
+}

--- a/src/main/java/com/danahub/zipitda/community/controller/LikeController.java
+++ b/src/main/java/com/danahub/zipitda/community/controller/LikeController.java
@@ -1,4 +1,35 @@
 package com.danahub.zipitda.community.controller;
 
+import com.danahub.zipitda.common.dto.CommonResponse;
+import com.danahub.zipitda.community.dto.LikeRequestDto;
+import com.danahub.zipitda.community.service.LikeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/community/likes")
+@RequiredArgsConstructor
+@Tag(name = "Like", description = "좋아요 관리 API")
 public class LikeController {
+
+    private final LikeService likeService;
+
+    @PostMapping
+    @Operation(summary = "좋아요 API", description = "좋아요를 클릭합니다.")
+    public void likePost(@RequestBody LikeRequestDto requestDto) {
+        likeService.likePost(requestDto.userId(), requestDto.postId());
+    }
+    @DeleteMapping
+    @Operation(summary = "좋아요 해제 API", description = "좋아요를 해제합니다.")
+    public void unlikePost(@RequestBody LikeRequestDto requestDto) {
+        likeService.unlikePost(requestDto.userId(), requestDto.postId());
+    }
+
+    @GetMapping
+    @Operation(summary = "좋아요 수 조회 API", description = "해당 포스트의 좋아요 수를 조회합니다.")
+    public CommonResponse<Long> countPostLikes(@RequestParam Long postId) {
+        return CommonResponse.success(likeService.countPostLikes(postId));
+    }
 }

--- a/src/main/java/com/danahub/zipitda/community/domain/Like.java
+++ b/src/main/java/com/danahub/zipitda/community/domain/Like.java
@@ -7,7 +7,10 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "likes")
+@Table(name = "likes",
+       uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "target_type", "target_id"})
+})
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/danahub/zipitda/community/dto/LikeRequestDto.java
+++ b/src/main/java/com/danahub/zipitda/community/dto/LikeRequestDto.java
@@ -1,0 +1,6 @@
+package com.danahub.zipitda.community.dto;
+
+public record LikeRequestDto(
+        Long userId,
+        Long postId
+) {}

--- a/src/main/java/com/danahub/zipitda/community/repository/LikeRepository.java
+++ b/src/main/java/com/danahub/zipitda/community/repository/LikeRepository.java
@@ -3,5 +3,11 @@ package com.danahub.zipitda.community.repository;
 import com.danahub.zipitda.community.domain.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    Optional<Like> findByUserIdAndTargetTypeAndTargetId(Long userId, String targetType, Long targetId);
+
+    long countByTargetTypeAndTargetId(String targetType, Long targetId);
 }

--- a/src/main/java/com/danahub/zipitda/community/repository/LikeRepository.java
+++ b/src/main/java/com/danahub/zipitda/community/repository/LikeRepository.java
@@ -1,0 +1,7 @@
+package com.danahub.zipitda.community.repository;
+
+import com.danahub.zipitda.community.domain.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+}

--- a/src/main/java/com/danahub/zipitda/community/service/LikeService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/LikeService.java
@@ -1,0 +1,49 @@
+package com.danahub.zipitda.community.service;
+
+import com.danahub.zipitda.common.exception.ErrorType;
+import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.danahub.zipitda.community.domain.Like;
+import com.danahub.zipitda.community.repository.LikeRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+
+    private static final String TARGET_TYPE_POST = "POST";
+
+    @Transactional
+    public void likePost(Long userId, Long postId) {
+        boolean alreadyLiked = likeRepository
+                .findByUserIdAndTargetTypeAndTargetId(userId, TARGET_TYPE_POST, postId)
+                .isPresent();
+
+        if (alreadyLiked) {
+            throw new ZipitdaException(ErrorType.LOCK_FAILED);
+        }
+
+        Like like = Like.builder()
+                .userId(userId)
+                .targetType(TARGET_TYPE_POST)
+                .targetId(postId)
+                .build();
+
+        likeRepository.save(like);
+    }
+
+    public void unlikePost(Long userId, Long postId) {
+        Like like = likeRepository
+                .findByUserIdAndTargetTypeAndTargetId(userId, TARGET_TYPE_POST, postId)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.RESOURCE_NOT_FOUND));
+
+        likeRepository.delete(like);
+    }
+
+    public long countPostLikes(Long postId) {
+        return likeRepository.countByTargetTypeAndTargetId(TARGET_TYPE_POST, postId);
+    }
+}

--- a/src/main/java/com/danahub/zipitda/community/service/LikeService.java
+++ b/src/main/java/com/danahub/zipitda/community/service/LikeService.java
@@ -6,6 +6,7 @@ import com.danahub.zipitda.community.domain.Like;
 import com.danahub.zipitda.community.repository.LikeRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -32,7 +33,12 @@ public class LikeService {
                 .targetId(postId)
                 .build();
 
-        likeRepository.save(like);
+        try {
+            likeRepository.save(like);
+        } catch (DataIntegrityViolationException e) {
+            // 이미 존재하는 좋아요일 경우
+            throw new ZipitdaException(ErrorType.ALREADY_LIKED);
+        }
     }
 
     public void unlikePost(Long userId, Long postId) {


### PR DESCRIPTION
- 커뮤니티 게시글에 좋아요를 추가/취소하는 기능 구현
- 동시에 여러 사용자가 좋아요 요청 시 발생 가능한 중복 문제를 방지
  - DB 레벨에서 유니크 제약 조건 설정
  - DataIntegrityViolationException을 활용한 중복 예외 처리
    - 중복 좋아요 요청 → ALREADY_LIKED 예외 반환
Closes #35 