### PR TITLE
[#79] 약관 이중쓰기 문제 해결

### DIFF
--- a/src/main/java/com/danahub/zipitda/common/exception/ErrorType.java
+++ b/src/main/java/com/danahub/zipitda/common/exception/ErrorType.java
@@ -41,6 +41,7 @@ public enum ErrorType {
     SHIPPING_NOT_FOUND(40406, HttpStatus.NOT_FOUND, "배송 정보를 찾을 수 없습니다."),
     CART_EMPTY(40407, HttpStatus.NOT_FOUND, "장바구니가 비었습니다."),
     IMAGE_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다."),
+    TERM_NOT_FOUND(40409, HttpStatus.NOT_FOUND, "약관을 찾을 수 없습니다."),
 
     // 409 CONFLICT - 리소스 충돌
     DUPLICATE_EMAIL(40900, HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
@@ -51,6 +52,8 @@ public enum ErrorType {
     SHIPPING_ALREADY_PROCESSED(40905, HttpStatus.CONFLICT, "배송이 이미 처리 중이거나 완료되었습니다."),
     LOCK_FAILED(40906, HttpStatus.CONFLICT, "재고 처리 중 잠금에 실패했습니다. 다시 시도해주세요."),
     ALREADY_LIKED(40907, HttpStatus.CONFLICT, "이미 좋아요한 게시글입니다."),
+    TERM_ALREADY_EXISTS(40908, HttpStatus.CONFLICT, "해당 약관(title, version)은 이미 존재합니다."),
+
 
     // 410 GONE - 리소스 만료
     VERIFICATION_EXPIRED(41000, HttpStatus.GONE, "인증 코드가 만료되었습니다."),
@@ -62,6 +65,8 @@ public enum ErrorType {
     VERIFICATION_CODE_MISMATCH(42203, HttpStatus.UNPROCESSABLE_ENTITY, "인증 코드가 일치하지 않습니다."),
     VERIFICATION_NOT_COMPLETED(42205, HttpStatus.UNPROCESSABLE_ENTITY, "인증이 완료되지 않았습니다."),
     INVALID_ORDER_STATUS_TRANSITION(42206, HttpStatus.UNPROCESSABLE_ENTITY, "잘못된 주문 상태 전환입니다."),
+    INVALID_TERM_VERSION(42210, HttpStatus.UNPROCESSABLE_ENTITY, "유효하지 않은 약관 버전입니다."),
+    INVALID_TERM_TITLE(42211, HttpStatus.UNPROCESSABLE_ENTITY, "유효하지 않은 약관 제목입니다."),
 
     // 500 INTERNAL SERVER ERROR - 서버 오류
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),

--- a/src/main/java/com/danahub/zipitda/common/exception/ErrorType.java
+++ b/src/main/java/com/danahub/zipitda/common/exception/ErrorType.java
@@ -53,7 +53,7 @@ public enum ErrorType {
     LOCK_FAILED(40906, HttpStatus.CONFLICT, "재고 처리 중 잠금에 실패했습니다. 다시 시도해주세요."),
     ALREADY_LIKED(40907, HttpStatus.CONFLICT, "이미 좋아요한 게시글입니다."),
     TERM_ALREADY_EXISTS(40908, HttpStatus.CONFLICT, "해당 약관(title, version)은 이미 존재합니다."),
-
+    CONCURRENT_UPDATE_CONFLICT(40909, HttpStatus.CONFLICT, "다른 사용자에 의해 약관이 수정되었습니다. 최신 내용을 확인해주세요."),
 
     // 410 GONE - 리소스 만료
     VERIFICATION_EXPIRED(41000, HttpStatus.GONE, "인증 코드가 만료되었습니다."),

--- a/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
+++ b/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -46,12 +47,14 @@ public class TermsController {
         return CommonResponse.success(termsService.getTermsByTitleAndVersion(title, version));
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
     @Operation(summary = "약관 등록 API", description = "신규 약관을 등록합니다.")
     public void createTerms(@Valid @RequestBody TermsRequestDto requestDto) {
         termsService.createTerms(requestDto);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/{title}/{version}")
     @Operation(summary = "약관 수정 API", description = "특정 약관의 내용을 수정합니다.")
     public void updateTerms(
@@ -61,6 +64,7 @@ public class TermsController {
         termsService.updateTerms(title, version, requestDto);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{title}/{version}")
     @Operation(summary = "약관 삭제 API", description = "특정 약관을 삭제합니다.")
     public void deleteTerms(@PathVariable String title, @PathVariable Integer version) {

--- a/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
+++ b/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
@@ -2,6 +2,7 @@ package com.danahub.zipitda.terms.controller;
 
 import com.danahub.zipitda.common.dto.CommonResponse;
 import com.danahub.zipitda.terms.domain.Terms;
+import com.danahub.zipitda.terms.dto.TermsListResponseDto;
 import com.danahub.zipitda.terms.dto.TermsRequestDto;
 import com.danahub.zipitda.terms.dto.TermsResponseDto;
 import com.danahub.zipitda.terms.service.TermsService;
@@ -27,9 +28,14 @@ public class TermsController {
     private final TermsService termsService;
 
     @GetMapping
-    @Operation(summary = "약관 전체 조회 API", description = "약관을 전체 조회합니다.")
+    @Operation(summary = "전체 약관 페이징 조회", description = "모든 약관(version 포함)을 페이징하여 조회합니다.")
     public CommonResponse<Page<TermsResponseDto>> getAllTerms(Pageable pageable) {
         return CommonResponse.success(termsService.getAllTerms(pageable));
+    }
+    @GetMapping("/latest")
+    @Operation(summary = "최신 약관 목록 조회", description = "약관 제목별 최신 버전만 조회합니다.")
+    public CommonResponse<TermsListResponseDto> getAllLatestTerms() {
+        return CommonResponse.success(termsService.getAllLatestTerms());
     }
 
     @GetMapping("/{title}/{version}")

--- a/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
+++ b/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
@@ -2,19 +2,18 @@ package com.danahub.zipitda.terms.controller;
 
 import com.danahub.zipitda.common.dto.CommonResponse;
 import com.danahub.zipitda.terms.domain.Terms;
+import com.danahub.zipitda.terms.dto.TermsRequestDto;
 import com.danahub.zipitda.terms.dto.TermsResponseDto;
 import com.danahub.zipitda.terms.service.TermsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -39,6 +38,27 @@ public class TermsController {
             @PathVariable String title,
             @PathVariable Integer version) {
         return CommonResponse.success(termsService.getTermsByTitleAndVersion(title, version));
+    }
+
+    @PostMapping
+    @Operation(summary = "약관 등록 API", description = "신규 약관을 등록합니다.")
+    public void createTerms(@Valid @RequestBody TermsRequestDto requestDto) {
+        termsService.createTerms(requestDto);
+    }
+
+    @PutMapping("/{title}/{version}")
+    @Operation(summary = "약관 수정 API", description = "특정 약관의 내용을 수정합니다.")
+    public void updateTerms(
+            @PathVariable String title,
+            @PathVariable Integer version,
+            @Valid @RequestBody TermsRequestDto requestDto) {
+        termsService.updateTerms(title, version, requestDto);
+    }
+
+    @DeleteMapping("/{title}/{version}")
+    @Operation(summary = "약관 삭제 API", description = "특정 약관을 삭제합니다.")
+    public void deleteTerms(@PathVariable String title, @PathVariable Integer version) {
+        termsService.deleteTerms(title, version);
     }
 
 }

--- a/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
+++ b/src/main/java/com/danahub/zipitda/terms/controller/TermsController.java
@@ -1,10 +1,15 @@
 package com.danahub.zipitda.terms.controller;
 
+import com.danahub.zipitda.common.dto.CommonResponse;
 import com.danahub.zipitda.terms.domain.Terms;
 import com.danahub.zipitda.terms.dto.TermsResponseDto;
 import com.danahub.zipitda.terms.service.TermsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,35 +22,23 @@ import java.util.List;
 @RequestMapping("/api/terms")
 @Slf4j
 @RequiredArgsConstructor
+@Tag(name = "term", description = "약관 API")
 public class TermsController {
 
     private final TermsService termsService;
 
-    // 약관 리스트 가져오기
-    @GetMapping("/list")
-    public ResponseEntity<List<TermsResponseDto>> getTermsList() {
-        log.info("[TermsController] /api/terms 요청 수신 - 약관 리스트 조회 시작");
-        List<TermsResponseDto> termsList = termsService.getTermsList();
-
-        if (termsList.isEmpty()) {
-            log.warn("[TermsController] 약관 데이터가 없습니다.");
-            return ResponseEntity.noContent().build(); // 204 No Content 반환
-        }
-
-        log.info("[TermsController] 약관 리스트 응답 성공 - 총 {}건 반환", termsList.size());
-        return ResponseEntity.ok(termsList); // 200 OK 반환
+    @GetMapping
+    @Operation(summary = "약관 전체 조회 API", description = "약관을 전체 조회합니다.")
+    public CommonResponse<Page<TermsResponseDto>> getAllTerms(Pageable pageable) {
+        return CommonResponse.success(termsService.getAllTerms(pageable));
     }
 
-    // 특정 약관 가져오기 (복합키)
     @GetMapping("/{title}/{version}")
-    public ResponseEntity<Terms> getTermsByTitleAndVersion(
+    @Operation(summary = "특정 약관 조회 API", description = "약관제목과 버전으로 특정 약관을 가져옵니다.")
+    public CommonResponse<TermsResponseDto> getTermsByTitleAndVersion(
             @PathVariable String title,
             @PathVariable Integer version) {
-        log.info("[TermsController] /api/terms/{}/{} 요청 수신 - 특정 약관 조회 시작", title, version);
-        Terms terms = termsService.getTermsByTitleAndVersion(title, version);
-
-        log.info("[TermsController] 특정 약관 조회 성공 - title: {}, version: {}", title, version);
-        return ResponseEntity.ok(terms); // 200 OK 반환
+        return CommonResponse.success(termsService.getTermsByTitleAndVersion(title, version));
     }
 
 }

--- a/src/main/java/com/danahub/zipitda/terms/domain/Terms.java
+++ b/src/main/java/com/danahub/zipitda/terms/domain/Terms.java
@@ -23,4 +23,8 @@ public class Terms extends BaseEntity {
     @Column(nullable = false)
     private Boolean required; // 필수 약관 여부 (true: 필수, false: 선택)
 
+    @Version
+    @Column(name = "version_number")
+    private Long versionNumber; // 낙관적 락용 필드
+
 }

--- a/src/main/java/com/danahub/zipitda/terms/domain/Terms.java
+++ b/src/main/java/com/danahub/zipitda/terms/domain/Terms.java
@@ -21,6 +21,6 @@ public class Terms extends BaseEntity {
     private String content; // 약관 내용
 
     @Column(nullable = false)
-    private Boolean isRequired; // 필수 약관 여부 (true: 필수, false: 선택)
+    private Boolean required; // 필수 약관 여부 (true: 필수, false: 선택)
 
 }

--- a/src/main/java/com/danahub/zipitda/terms/dto/TermsListResponseDto.java
+++ b/src/main/java/com/danahub/zipitda/terms/dto/TermsListResponseDto.java
@@ -1,0 +1,11 @@
+package com.danahub.zipitda.terms.dto;
+
+import java.util.List;
+
+public record TermsListResponseDto(
+        List<TermsResponseDto> termsList
+) {
+    public static TermsListResponseDto from(List<TermsResponseDto> list) {
+        return new TermsListResponseDto(list);
+    }
+}

--- a/src/main/java/com/danahub/zipitda/terms/dto/TermsRequestDto.java
+++ b/src/main/java/com/danahub/zipitda/terms/dto/TermsRequestDto.java
@@ -6,13 +6,12 @@ import jakarta.validation.constraints.NotNull;
 public record TermsRequestDto(
         @NotBlank(message = "약관 제목은 필수입니다.")
         String title,
-
         @NotNull(message = "약관 버전은 필수입니다.")
         Integer version,
-
         @NotBlank(message = "약관 내용은 필수입니다.")
         String content,
-
         @NotNull(message = "필수 여부는 필수입니다.")
-        Boolean required
+        Boolean required,
+        @NotNull(message = "버전번호는 필수입니다.")
+        Long versionNumber
 ) {}

--- a/src/main/java/com/danahub/zipitda/terms/dto/TermsRequestDto.java
+++ b/src/main/java/com/danahub/zipitda/terms/dto/TermsRequestDto.java
@@ -1,0 +1,18 @@
+package com.danahub.zipitda.terms.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record TermsRequestDto(
+        @NotBlank(message = "약관 제목은 필수입니다.")
+        String title,
+
+        @NotNull(message = "약관 버전은 필수입니다.")
+        Integer version,
+
+        @NotBlank(message = "약관 내용은 필수입니다.")
+        String content,
+
+        @NotNull(message = "필수 여부는 필수입니다.")
+        Boolean required
+) {}

--- a/src/main/java/com/danahub/zipitda/terms/dto/TermsResponseDto.java
+++ b/src/main/java/com/danahub/zipitda/terms/dto/TermsResponseDto.java
@@ -1,14 +1,27 @@
 package com.danahub.zipitda.terms.dto;
 
+import com.danahub.zipitda.terms.domain.Terms;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import java.time.LocalDateTime;
 
-@Data
-public class TermsResponseDto {
-    private String title;
-    private int version;
-    private String content;
-    private boolean isRequired;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+public record TermsResponseDto(
+        String title,
+        Integer version,
+        String content,
+        Boolean required,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+        public static TermsResponseDto fromEntity(Terms terms) {
+                return new TermsResponseDto(
+                        terms.getId().getTitle(),           // 복합키에서 title 추출
+                        terms.getId().getVersion(),         // 복합키에서 version 추출
+                        terms.getContent(),
+                        terms.getRequired(),
+                        terms.getCreatedAt(),
+                        terms.getUpdatedAt()
+                );
+        }
 }

--- a/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
+++ b/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -63,16 +64,24 @@ public class TermsService {
         termsRepository.save(terms);
     }
 
-    // 약관 수정
     public void updateTerms(String title, Integer version, TermsRequestDto requestDto) {
         TermsId termsId = new TermsId(title, version);
         Terms terms = termsRepository.findById(termsId)
                 .orElseThrow(() -> new ZipitdaException(ErrorType.TERM_NOT_FOUND));
 
+        // 낙관적 락 적용 : 요청된 versionNumber와 DB 버전 비교
+        if (!terms.getVersionNumber().equals(requestDto.versionNumber())) {
+            throw new ZipitdaException(ErrorType.CONCURRENT_UPDATE_CONFLICT);
+        }
+
         terms.setContent(requestDto.content());
         terms.setRequired(requestDto.required());
 
-        termsRepository.save(terms);
+        try {
+            termsRepository.save(terms);
+        } catch (ObjectOptimisticLockingFailureException e) {
+            throw new ZipitdaException(ErrorType.CONCURRENT_UPDATE_CONFLICT);
+        }
     }
 
     // 약관 삭제

--- a/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
+++ b/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
@@ -5,6 +5,7 @@ import com.danahub.zipitda.common.exception.ZipitdaException;
 import com.danahub.zipitda.store.dto.ProductResponseDto;
 import com.danahub.zipitda.terms.domain.Terms;
 import com.danahub.zipitda.terms.domain.TermsId;
+import com.danahub.zipitda.terms.dto.TermsRequestDto;
 import com.danahub.zipitda.terms.dto.TermsResponseDto;
 import com.danahub.zipitda.terms.mapper.TermsMapper;
 import com.danahub.zipitda.terms.repository.TermsRepository;
@@ -35,5 +36,42 @@ public class TermsService {
         Terms terms = termsRepository.findById(termsId)
                 .orElseThrow(() -> new ZipitdaException(ErrorType.TERM_NOT_FOUND));
         return TermsResponseDto.fromEntity(terms);
+    }
+
+    // 약관 등록
+    public void createTerms(TermsRequestDto requestDto) {
+        TermsId termsId = new TermsId(requestDto.title(), requestDto.version());
+
+        if (termsRepository.existsById(termsId)) {
+            throw new ZipitdaException(ErrorType.TERM_ALREADY_EXISTS);
+        }
+
+        Terms terms = new Terms();
+        terms.setId(termsId);
+        terms.setContent(requestDto.content());
+        terms.setRequired(requestDto.required());
+
+        termsRepository.save(terms);
+    }
+
+    // 약관 수정
+    public void updateTerms(String title, Integer version, TermsRequestDto requestDto) {
+        TermsId termsId = new TermsId(title, version);
+        Terms terms = termsRepository.findById(termsId)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.TERM_NOT_FOUND));
+
+        terms.setContent(requestDto.content());
+        terms.setRequired(requestDto.required());
+
+        termsRepository.save(terms);
+    }
+
+    // 약관 삭제
+    public void deleteTerms(String title, Integer version) {
+        TermsId termsId = new TermsId(title, version);
+        Terms terms = termsRepository.findById(termsId)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.TERM_NOT_FOUND));
+
+        termsRepository.delete(terms);
     }
 }

--- a/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
+++ b/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
@@ -1,5 +1,8 @@
 package com.danahub.zipitda.terms.service;
 
+import com.danahub.zipitda.common.exception.ErrorType;
+import com.danahub.zipitda.common.exception.ZipitdaException;
+import com.danahub.zipitda.store.dto.ProductResponseDto;
 import com.danahub.zipitda.terms.domain.Terms;
 import com.danahub.zipitda.terms.domain.TermsId;
 import com.danahub.zipitda.terms.dto.TermsResponseDto;
@@ -7,6 +10,8 @@ import com.danahub.zipitda.terms.mapper.TermsMapper;
 import com.danahub.zipitda.terms.repository.TermsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,21 +21,19 @@ import java.util.List;
 @Slf4j
 public class TermsService {
 
-    private final TermsMapper termsMapper;
     private final TermsRepository termsRepository;
 
-
     // 약관 리스트 가져오기
-    public List<TermsResponseDto> getTermsList() {
-        List<TermsResponseDto> termsList = termsMapper.getTermsList();
-        return termsList;
+    public Page<TermsResponseDto> getAllTerms(Pageable pageable) {
+        return termsRepository.findAll(pageable)
+                .map(TermsResponseDto::fromEntity);
     }
 
     // 특정 약관 가져오기 (복합키)
-    public Terms getTermsByTitleAndVersion(String title, Integer version) {
+    public TermsResponseDto getTermsByTitleAndVersion(String title, Integer version) {
         TermsId termsId = new TermsId(title, version);
-        return termsRepository.findById(termsId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 약관을 찾을 수 없습니다."));
+        Terms terms = termsRepository.findById(termsId)
+                .orElseThrow(() -> new ZipitdaException(ErrorType.TERM_NOT_FOUND));
+        return TermsResponseDto.fromEntity(terms);
     }
-
 }

--- a/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
+++ b/src/main/java/com/danahub/zipitda/terms/service/TermsService.java
@@ -5,6 +5,7 @@ import com.danahub.zipitda.common.exception.ZipitdaException;
 import com.danahub.zipitda.store.dto.ProductResponseDto;
 import com.danahub.zipitda.terms.domain.Terms;
 import com.danahub.zipitda.terms.domain.TermsId;
+import com.danahub.zipitda.terms.dto.TermsListResponseDto;
 import com.danahub.zipitda.terms.dto.TermsRequestDto;
 import com.danahub.zipitda.terms.dto.TermsResponseDto;
 import com.danahub.zipitda.terms.mapper.TermsMapper;
@@ -24,10 +25,18 @@ public class TermsService {
 
     private final TermsRepository termsRepository;
 
-    // 약관 리스트 가져오기
     public Page<TermsResponseDto> getAllTerms(Pageable pageable) {
         return termsRepository.findAll(pageable)
                 .map(TermsResponseDto::fromEntity);
+    }
+
+    // 최신 약관 리스트 가져오기
+    public TermsListResponseDto getAllLatestTerms() {
+        List<Terms> latestTerms = termsRepository.findLatestTermsByTitle();
+        List<TermsResponseDto> dtoList = latestTerms.stream()
+                .map(TermsResponseDto::fromEntity)
+                .toList();
+        return TermsListResponseDto.from(dtoList);
     }
 
     // 특정 약관 가져오기 (복합키)


### PR DESCRIPTION
- JPA @Version 기반 낙관적 락으로 해결
  - DB에 versionNumber 필드를 두고 JPA가 WHERE versionNumber=? 조건으로 update
  - 충돌 시 OptimisticLockingFailureException 발생

- DB에 versionNumber 필드 추가
Closes #79 